### PR TITLE
tests: fix TestSortValues on 32-bits platforms

### DIFF
--- a/spew/common_test.go
+++ b/spew/common_test.go
@@ -116,6 +116,14 @@ func testFailed(result string, wants []string) bool {
 // TestSortValues ensures the sort functionality for relect.Value based sorting
 // works as intended.
 func TestSortValues(t *testing.T) {
+	getInterfaces := func(values []reflect.Value) []interface{} {
+		interfaces := []interface{}{}
+		for _, v := range values {
+			interfaces = append(interfaces, v.Interface())
+		}
+		return interfaces
+	}
+
 	v := reflect.ValueOf
 
 	a := v("a")
@@ -171,8 +179,14 @@ func TestSortValues(t *testing.T) {
 	}
 	for _, test := range tests {
 		spew.SortValues(test.input)
-		if !reflect.DeepEqual(test.input, test.expected) {
-			t.Errorf("Sort mismatch:\n %v != %v", test.input, test.expected)
+		// reflect.DeepEqual cannot really make sense of reflect.Value,
+		// probably because of all the pointer tricks. For instance,
+		// v(2.0) != v(2.0) on a 32-bits system. Turn them into interface{}
+		// instead.
+		input := getInterfaces(test.input)
+		expected := getInterfaces(test.expected)
+		if !reflect.DeepEqual(input, expected) {
+			t.Errorf("Sort mismatch:\n %v != %v", input, expected)
 		}
 	}
 }


### PR DESCRIPTION
reflect.DeepEqual fails when comparing reflect.Value containing float64. I
think it cannot make sense of reflect.Value pointer tricks and directly
compare reflect.Value.val fields which contain the float value in 64 bits,
but a pointer to the float in 32 bits.

Fortunately, interface{} which have a similar memory layout, compare correctly,
so we just turn the []reflect.Value into []interface{}.
