### PR TITLE
Add support for sorting keys that are arrays

### DIFF
--- a/spew/common.go
+++ b/spew/common.go
@@ -358,16 +358,6 @@ func valueSortLess(a, b reflect.Value) bool {
 	case reflect.Uintptr:
 		return a.Uint() < b.Uint()
 	case reflect.Array:
-		// Skip array types that do not support the == operator.
-		t := a.Type().Elem()
-		if t.Kind() == reflect.Interface {
-			t = a.Elem().Type()
-		}
-		switch t.Kind() {
-		case reflect.Slice, reflect.Map, reflect.Func:
-			goto unsupported
-		}
-
 		// Compare the contents of both arrays.
 		l := a.Len()
 		for i := 0; i < l; i++ {
@@ -380,8 +370,6 @@ func valueSortLess(a, b reflect.Value) bool {
 		}
 		return false
 	}
-
-unsupported:
 	return a.String() < b.String()
 }
 

--- a/spew/common.go
+++ b/spew/common.go
@@ -368,7 +368,6 @@ func valueSortLess(a, b reflect.Value) bool {
 			}
 			return valueSortLess(av, bv)
 		}
-		return false
 	}
 	return a.String() < b.String()
 }

--- a/spew/common.go
+++ b/spew/common.go
@@ -369,9 +369,8 @@ func valueSortLess(a, b reflect.Value) bool {
 		}
 
 		// Compare the contents of both arrays.
-		al := a.Len()
-		bl := b.Len()
-		for i := 0; i < al && i < bl; i++ {
+		l := a.Len()
+		for i := 0; i < l; i++ {
 			av := a.Index(i)
 			bv := b.Index(i)
 			if av.Interface() == bv.Interface() {
@@ -379,7 +378,7 @@ func valueSortLess(a, b reflect.Value) bool {
 			}
 			return valueSortLess(av, bv)
 		}
-		return al < bl
+		return false
 	}
 
 unsupported:

--- a/spew/common_test.go
+++ b/spew/common_test.go
@@ -168,8 +168,8 @@ func TestSortValues(t *testing.T) {
 		},
 		// Array
 		{
-			[]reflect.Value{v([...]int{3, 2, 1}), v([...]int{1, 3, 2}), v([...]int{1, 2, 3}), v([...]int{}), v([...]int{2, 1})},
-			[]reflect.Value{v([...]int{}), v([...]int{1, 2, 3}), v([...]int{1, 3, 2}), v([...]int{2, 1}), v([...]int{3, 2, 1})},
+			[]reflect.Value{v([3]int{3, 2, 1}), v([3]int{1, 3, 2}), v([3]int{1, 2, 3})},
+			[]reflect.Value{v([3]int{1, 2, 3}), v([3]int{1, 3, 2}), v([3]int{3, 2, 1})},
 		},
 		// Uintptrs.
 		{

--- a/spew/common_test.go
+++ b/spew/common_test.go
@@ -166,6 +166,11 @@ func TestSortValues(t *testing.T) {
 			[]reflect.Value{b, a, c},
 			[]reflect.Value{a, b, c},
 		},
+		// Array
+		{
+			[]reflect.Value{v([...]int{3, 2, 1}), v([...]int{1, 3, 2}), v([...]int{1, 2, 3}), v([...]int{}), v([...]int{2, 1})},
+			[]reflect.Value{v([...]int{}), v([...]int{1, 2, 3}), v([...]int{1, 3, 2}), v([...]int{2, 1}), v([...]int{3, 2, 1})},
+		},
 		// Uintptrs.
 		{
 			[]reflect.Value{v(uintptr(2)), v(uintptr(1)), v(uintptr(3))},


### PR DESCRIPTION
The String method of reflect.Value always returns the same result for two different arrays, regardless of their content (e.g. `[4]int` always produces `"<[4]int Value>"`). This causes inconsistent sorting for maps whose keys are arrays.