### PR TITLE
Add support for limited mode without unsafe pkg.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ go: 1.2
 install:
     - go get -v code.google.com/p/go.tools/cmd/cover
 script:
+    - go test -v -tags=disableunsafe ./spew
     - go test -v -tags=testcgo ./spew -covermode=count -coverprofile=profile.cov
 after_success:
     - go get -v github.com/mattn/goveralls

--- a/README.md
+++ b/README.md
@@ -154,7 +154,10 @@ options. See the ConfigState documentation for more details.
 
 * DisablePointerMethods
 	Disables invocation of error and Stringer interface methods on types
-	which only accept pointer receivers from non-pointer variables.
+	which only accept pointer receivers from non-pointer variables.  This option
+	relies on access to the unsafe package, so it will not have any effect when
+	running in environments without access to the unsafe package such as Google
+	App Engine or with the "disableunsafe" build tag specified.
 	Pointer method invocation is enabled by default.
 
 * ContinueOnMethod
@@ -176,6 +179,15 @@ options. See the ConfigState documentation for more details.
 	if SortKeys is true.
 
 ```
+
+## Unsafe Package Dependency
+
+This package relies on the unsafe package to perform some of the more advanced
+features, however it also supports a "limited" mode which allows it to work in
+environments where the unsafe package is not available.  By default, it will
+operate in this mode on Google App Engine.  The "disableunsafe" build tag may
+also be specified to force the package to build without using the unsafe
+package.
 
 ## License
 

--- a/spew/bypass.go
+++ b/spew/bypass.go
@@ -1,0 +1,136 @@
+// Copyright (c) 2015 Dave Collins <dave@davec.name>
+//
+// Permission to use, copy, modify, and distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+// WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+// MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+// ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+// WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+// ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+// OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+// NOTE: Due to the following build constraints, this file will only be compiled
+// when the code is not running on Google App Engine and "-tags disableunsafe"
+// is not added to the go build command line.
+// +build !appengine,!disableunsafe
+
+package spew
+
+import (
+	"reflect"
+	"unsafe"
+)
+
+const (
+	// UnsafeDisabled is a build-time constant which specifies whether or
+	// not access to the unsafe package is available.
+	UnsafeDisabled = false
+
+	// ptrSize is the size of a pointer on the current arch.
+	ptrSize = unsafe.Sizeof((*byte)(nil))
+)
+
+var (
+	// offsetPtr, offsetScalar, and offsetFlag are the offsets for the
+	// internal reflect.Value fields.  These values are valid before golang
+	// commit ecccf07e7f9d which changed the format.  The are also valid
+	// after commit 82f48826c6c7 which changed the format again to mirror
+	// the original format.  Code in the init function updates these offsets
+	// as necessary.
+	offsetPtr    = uintptr(ptrSize)
+	offsetScalar = uintptr(0)
+	offsetFlag   = uintptr(ptrSize * 2)
+
+	// flagKindWidth and flagKindShift indicate various bits that the
+	// reflect package uses internally to track kind information.
+	//
+	// flagRO indicates whether or not the value field of a reflect.Value is
+	// read-only.
+	//
+	// flagIndir indicates whether the value field of a reflect.Value is
+	// the actual data or a pointer to the data.
+	//
+	// These values are valid before golang commit 90a7c3c86944 which
+	// changed their positions.  Code in the init function updates these
+	// flags as necessary.
+	flagKindWidth = uintptr(5)
+	flagKindShift = uintptr(flagKindWidth - 1)
+	flagRO        = uintptr(1 << 0)
+	flagIndir     = uintptr(1 << 1)
+)
+
+func init() {
+	// Older versions of reflect.Value stored small integers directly in the
+	// ptr field (which is named val in the older versions).  Versions
+	// between commits ecccf07e7f9d and 82f48826c6c7 added a new field named
+	// scalar for this purpose which unfortunately came before the flag
+	// field, so the offset of the flag field is different for those
+	// versions.
+	//
+	// This code constructs a new reflect.Value from a known small integer
+	// and checks if the size of the reflect.Value struct indicates it has
+	// the scalar field. When it does, the offsets are updated accordingly.
+	vv := reflect.ValueOf(0xf00)
+	if unsafe.Sizeof(vv) == (ptrSize * 4) {
+		offsetScalar = ptrSize * 2
+		offsetFlag = ptrSize * 3
+	}
+
+	// Commit 90a7c3c86944 changed the flag positions such that the low
+	// order bits are the kind.  This code extracts the kind from the flags
+	// field and ensures it's the correct type.  When it's not, the flag
+	// order has been changed to the newer format, so the flags are updated
+	// accordingly.
+	upf := unsafe.Pointer(uintptr(unsafe.Pointer(&vv)) + offsetFlag)
+	upfv := *(*uintptr)(upf)
+	flagKindMask := uintptr((1<<flagKindWidth - 1) << flagKindShift)
+	if (upfv&flagKindMask)>>flagKindShift != uintptr(reflect.Int) {
+		flagKindShift = 0
+		flagRO = 1 << 5
+		flagIndir = 1 << 6
+	}
+}
+
+// unsafeReflectValue converts the passed reflect.Value into a one that bypasses
+// the typical safety restrictions preventing access to unaddressable and
+// unexported data.  It works by digging the raw pointer to the underlying
+// value out of the protected value and generating a new unprotected (unsafe)
+// reflect.Value to it.
+//
+// This allows us to check for implementations of the Stringer and error
+// interfaces to be used for pretty printing ordinarily unaddressable and
+// inaccessible values such as unexported struct fields.
+func unsafeReflectValue(v reflect.Value) (rv reflect.Value) {
+	indirects := 1
+	vt := v.Type()
+	upv := unsafe.Pointer(uintptr(unsafe.Pointer(&v)) + offsetPtr)
+	rvf := *(*uintptr)(unsafe.Pointer(uintptr(unsafe.Pointer(&v)) + offsetFlag))
+	if rvf&flagIndir != 0 {
+		vt = reflect.PtrTo(v.Type())
+		indirects++
+	} else if offsetScalar != 0 {
+		// The value is in the scalar field when it's not one of the
+		// reference types.
+		switch vt.Kind() {
+		case reflect.Uintptr:
+		case reflect.Chan:
+		case reflect.Func:
+		case reflect.Map:
+		case reflect.Ptr:
+		case reflect.UnsafePointer:
+		default:
+			upv = unsafe.Pointer(uintptr(unsafe.Pointer(&v)) +
+				offsetScalar)
+		}
+	}
+
+	pv := reflect.NewAt(vt, upv)
+	rv = pv
+	for i := 0; i < indirects; i++ {
+		rv = rv.Elem()
+	}
+	return rv
+}

--- a/spew/bypasssafe.go
+++ b/spew/bypasssafe.go
@@ -1,0 +1,37 @@
+// Copyright (c) 2015 Dave Collins <dave@davec.name>
+//
+// Permission to use, copy, modify, and distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+// WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+// MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+// ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+// WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+// ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+// OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+// NOTE: Due to the following build constraints, this file will only be compiled
+// when either the code is running on Google App Engine or "-tags disableunsafe"
+// is added to the go build command line.
+// +build appengine disableunsafe
+
+package spew
+
+import "reflect"
+
+const (
+	// UnsafeDisabled is a build-time constant which specifies whether or
+	// not access to the unsafe package is available.
+	UnsafeDisabled = true
+)
+
+// unsafeReflectValue typically converts the passed reflect.Value into a one
+// that bypasses the typical safety restrictions preventing access to
+// unaddressable and unexported data.  However, doing this relies on access to
+// the unsafe package.  This is a stub version which simply returns the passed
+// reflect.Value when the unsafe package is not available.
+func unsafeReflectValue(v reflect.Value) reflect.Value {
+	return v
+}

--- a/spew/common.go
+++ b/spew/common.go
@@ -23,115 +23,7 @@ import (
 	"reflect"
 	"sort"
 	"strconv"
-	"unsafe"
 )
-
-const (
-	// ptrSize is the size of a pointer on the current arch.
-	ptrSize = unsafe.Sizeof((*byte)(nil))
-)
-
-var (
-	// offsetPtr, offsetScalar, and offsetFlag are the offsets for the
-	// internal reflect.Value fields.  These values are valid before golang
-	// commit ecccf07e7f9d which changed the format.  The are also valid
-	// after commit 82f48826c6c7 which changed the format again to mirror
-	// the original format.  Code in the init function updates these offsets
-	// as necessary.
-	offsetPtr    = uintptr(ptrSize)
-	offsetScalar = uintptr(0)
-	offsetFlag   = uintptr(ptrSize * 2)
-
-	// flagKindWidth and flagKindShift indicate various bits that the
-	// reflect package uses internally to track kind information.
-	//
-	// flagRO indicates whether or not the value field of a reflect.Value is
-	// read-only.
-	//
-	// flagIndir indicates whether the value field of a reflect.Value is
-	// the actual data or a pointer to the data.
-	//
-	// These values are valid before golang commit 90a7c3c86944 which
-	// changed their positions.  Code in the init function updates these
-	// flags as necessary.
-	flagKindWidth = uintptr(5)
-	flagKindShift = uintptr(flagKindWidth - 1)
-	flagRO        = uintptr(1 << 0)
-	flagIndir     = uintptr(1 << 1)
-)
-
-func init() {
-	// Older versions of reflect.Value stored small integers directly in the
-	// ptr field (which is named val in the older versions).  Versions
-	// between commits ecccf07e7f9d and 82f48826c6c7 added a new field named
-	// scalar for this purpose which unfortunately came before the flag
-	// field, so the offset of the flag field is different for those
-	// versions.
-	//
-	// This code constructs a new reflect.Value from a known small integer
-	// and checks if the size of the reflect.Value struct indicates it has
-	// the scalar field. When it does, the offsets are updated accordingly.
-	vv := reflect.ValueOf(0xf00)
-	if unsafe.Sizeof(vv) == (ptrSize * 4) {
-		offsetScalar = ptrSize * 2
-		offsetFlag = ptrSize * 3
-	}
-
-	// Commit 90a7c3c86944 changed the flag positions such that the low
-	// order bits are the kind.  This code extracts the kind from the flags
-	// field and ensures it's the correct type.  When it's not, the flag
-	// order has been changed to the newer format, so the flags are updated
-	// accordingly.
-	upf := unsafe.Pointer(uintptr(unsafe.Pointer(&vv)) + offsetFlag)
-	upfv := *(*uintptr)(upf)
-	flagKindMask := uintptr((1<<flagKindWidth - 1) << flagKindShift)
-	if (upfv&flagKindMask)>>flagKindShift != uintptr(reflect.Int) {
-		flagKindShift = 0
-		flagRO = 1 << 5
-		flagIndir = 1 << 6
-	}
-}
-
-// unsafeReflectValue converts the passed reflect.Value into a one that bypasses
-// the typical safety restrictions preventing access to unaddressable and
-// unexported data.  It works by digging the raw pointer to the underlying
-// value out of the protected value and generating a new unprotected (unsafe)
-// reflect.Value to it.
-//
-// This allows us to check for implementations of the Stringer and error
-// interfaces to be used for pretty printing ordinarily unaddressable and
-// inaccessible values such as unexported struct fields.
-func unsafeReflectValue(v reflect.Value) (rv reflect.Value) {
-	indirects := 1
-	vt := v.Type()
-	upv := unsafe.Pointer(uintptr(unsafe.Pointer(&v)) + offsetPtr)
-	rvf := *(*uintptr)(unsafe.Pointer(uintptr(unsafe.Pointer(&v)) + offsetFlag))
-	if rvf&flagIndir != 0 {
-		vt = reflect.PtrTo(v.Type())
-		indirects++
-	} else if offsetScalar != 0 {
-		// The value is in the scalar field when it's not one of the
-		// reference types.
-		switch vt.Kind() {
-		case reflect.Uintptr:
-		case reflect.Chan:
-		case reflect.Func:
-		case reflect.Map:
-		case reflect.Ptr:
-		case reflect.UnsafePointer:
-		default:
-			upv = unsafe.Pointer(uintptr(unsafe.Pointer(&v)) +
-				offsetScalar)
-		}
-	}
-
-	pv := reflect.NewAt(vt, upv)
-	rv = pv
-	for i := 0; i < indirects; i++ {
-		rv = rv.Elem()
-	}
-	return rv
-}
 
 // Some constants in the form of bytes to avoid string overhead.  This mirrors
 // the technique used in the fmt package.
@@ -194,9 +86,14 @@ func handleMethods(cs *ConfigState, w io.Writer, v reflect.Value) (handled bool)
 	// We need an interface to check if the type implements the error or
 	// Stringer interface.  However, the reflect package won't give us an
 	// interface on certain things like unexported struct fields in order
-	// to enforce visibility rules.  We use unsafe to bypass these restrictions
-	// since this package does not mutate the values.
+	// to enforce visibility rules.  We use unsafe, when it's available,
+	// to bypass these restrictions since this package does not mutate the
+	// values.
 	if !v.CanInterface() {
+		if UnsafeDisabled {
+			return false
+		}
+
 		v = unsafeReflectValue(v)
 	}
 
@@ -206,21 +103,15 @@ func handleMethods(cs *ConfigState, w io.Writer, v reflect.Value) (handled bool)
 	// mutate the value, however, types which choose to satisify an error or
 	// Stringer interface with a pointer receiver should not be mutating their
 	// state inside these interface methods.
-	var viface interface{}
-	if !cs.DisablePointerMethods {
-		if !v.CanAddr() {
-			v = unsafeReflectValue(v)
-		}
-		viface = v.Addr().Interface()
-	} else {
-		if v.CanAddr() {
-			v = v.Addr()
-		}
-		viface = v.Interface()
+	if !cs.DisablePointerMethods && !UnsafeDisabled && !v.CanAddr() {
+		v = unsafeReflectValue(v)
+	}
+	if v.CanAddr() {
+		v = v.Addr()
 	}
 
 	// Is it an error or Stringer?
-	switch iface := viface.(type) {
+	switch iface := v.Interface().(type) {
 	case error:
 		defer catchPanic(w, v)
 		if cs.ContinueOnMethod {

--- a/spew/config.go
+++ b/spew/config.go
@@ -61,7 +61,10 @@ type ConfigState struct {
 	// with a pointer receiver could technically mutate the value, however,
 	// in practice, types which choose to satisify an error or Stringer
 	// interface with a pointer receiver should not be mutating their state
-	// inside these interface methods.
+	// inside these interface methods.  As a result, this option relies on
+	// access to the unsafe package, so it will not have any effect when
+	// running in environments without access to the unsafe package such as
+	// Google App Engine or with the "disableunsafe" build tag specified.
 	DisablePointerMethods bool
 
 	// ContinueOnMethod specifies whether or not recursion should continue once

--- a/spew/dump.go
+++ b/spew/dump.go
@@ -181,25 +181,30 @@ func (d *dumpState) dumpSlice(v reflect.Value) {
 		// Try to use existing uint8 slices and fall back to converting
 		// and copying if that fails.
 		case vt.Kind() == reflect.Uint8:
-			// We need an addressable interface to convert the type back
-			// into a byte slice.  However, the reflect package won't give
-			// us an interface on certain things like unexported struct
-			// fields in order to enforce visibility rules.  We use unsafe
-			// to bypass these restrictions since this package does not
+			// TODO(davec): Fix up the disableUnsafe bits...
+
+			// We need an addressable interface to convert the type
+			// to a byte slice.  However, the reflect package won't
+			// give us an interface on certain things like
+			// unexported struct fields in order to enforce
+			// visibility rules.  We use unsafe, when available, to
+			// bypass these restrictions since this package does not
 			// mutate the values.
 			vs := v
 			if !vs.CanInterface() || !vs.CanAddr() {
 				vs = unsafeReflectValue(vs)
 			}
-			vs = vs.Slice(0, numEntries)
+			if !UnsafeDisabled {
+				vs = vs.Slice(0, numEntries)
 
-			// Use the existing uint8 slice if it can be type
-			// asserted.
-			iface := vs.Interface()
-			if slice, ok := iface.([]uint8); ok {
-				buf = slice
-				doHexDump = true
-				break
+				// Use the existing uint8 slice if it can be
+				// type asserted.
+				iface := vs.Interface()
+				if slice, ok := iface.([]uint8); ok {
+					buf = slice
+					doHexDump = true
+					break
+				}
 			}
 
 			// The underlying data needs to be converted if it can't

--- a/spew/dump_test.go
+++ b/spew/dump_test.go
@@ -334,13 +334,20 @@ func addArrayDumpTests() {
 	v2Addr := fmt.Sprintf("%p", pv2)
 	pv2Addr := fmt.Sprintf("%p", &pv2)
 	v2t := "spew_test.pstringer"
-	v2s := "(len=" + v2Len + " cap=" + v2Cap + ") {\n (" + v2t + ") (len=" +
-		v2i0Len + ") stringer 1,\n (" + v2t + ") (len=" + v2i1Len +
-		") stringer 2,\n (" + v2t + ") (len=" + v2i2Len + ") " +
-		"stringer 3\n}"
+	v2sp := "(len=" + v2Len + " cap=" + v2Cap + ") {\n (" + v2t +
+		") (len=" + v2i0Len + ") stringer 1,\n (" + v2t +
+		") (len=" + v2i1Len + ") stringer 2,\n (" + v2t +
+		") (len=" + v2i2Len + ") " + "stringer 3\n}"
+	v2s := v2sp
+	if spew.UnsafeDisabled {
+		v2s = "(len=" + v2Len + " cap=" + v2Cap + ") {\n (" + v2t +
+			") (len=" + v2i0Len + ") \"1\",\n (" + v2t + ") (len=" +
+			v2i1Len + ") \"2\",\n (" + v2t + ") (len=" + v2i2Len +
+			") " + "\"3\"\n}"
+	}
 	addDumpTest(v2, "([3]"+v2t+") "+v2s+"\n")
-	addDumpTest(pv2, "(*[3]"+v2t+")("+v2Addr+")("+v2s+")\n")
-	addDumpTest(&pv2, "(**[3]"+v2t+")("+pv2Addr+"->"+v2Addr+")("+v2s+")\n")
+	addDumpTest(pv2, "(*[3]"+v2t+")("+v2Addr+")("+v2sp+")\n")
+	addDumpTest(&pv2, "(**[3]"+v2t+")("+pv2Addr+"->"+v2Addr+")("+v2sp+")\n")
 	addDumpTest(nv2, "(*[3]"+v2t+")(<nil>)\n")
 
 	// Array containing interfaces.
@@ -587,6 +594,11 @@ func addMapDumpTests() {
 	m2t2 := "spew_test.pstringer"
 	m2s := "(len=" + m2Len + ") {\n (" + m2t1 + ") (len=" + k2Len + ") " +
 		"stringer one: (" + m2t2 + ") (len=" + v2Len + ") stringer 1\n}"
+	if spew.UnsafeDisabled {
+		m2s = "(len=" + m2Len + ") {\n (" + m2t1 + ") (len=" + k2Len +
+			") " + "\"one\": (" + m2t2 + ") (len=" + v2Len +
+			") \"1\"\n}"
+	}
 	addDumpTest(m2, "("+m2t+") "+m2s+"\n")
 	addDumpTest(pm2, "(*"+m2t+")("+m2Addr+")("+m2s+")\n")
 	addDumpTest(&pm2, "(**"+m2t+")("+pm2Addr+"->"+m2Addr+")("+m2s+")\n")
@@ -693,9 +705,16 @@ func addStructDumpTests() {
 	v3t2 := "spew_test.pstringer"
 	v3s := "{\n s: (" + v3t2 + ") (len=4) stringer test,\n S: (" + v3t2 +
 		") (len=5) stringer test2\n}"
+	v3sp := v3s
+	if spew.UnsafeDisabled {
+		v3s = "{\n s: (" + v3t2 + ") (len=4) \"test\",\n S: (" +
+			v3t2 + ") (len=5) \"test2\"\n}"
+		v3sp = "{\n s: (" + v3t2 + ") (len=4) \"test\",\n S: (" +
+			v3t2 + ") (len=5) stringer test2\n}"
+	}
 	addDumpTest(v3, "("+v3t+") "+v3s+"\n")
-	addDumpTest(pv3, "(*"+v3t+")("+v3Addr+")("+v3s+")\n")
-	addDumpTest(&pv3, "(**"+v3t+")("+pv3Addr+"->"+v3Addr+")("+v3s+")\n")
+	addDumpTest(pv3, "(*"+v3t+")("+v3Addr+")("+v3sp+")\n")
+	addDumpTest(&pv3, "(**"+v3t+")("+pv3Addr+"->"+v3Addr+")("+v3sp+")\n")
 	addDumpTest(nv3, "(*"+v3t+")(<nil>)\n")
 
 	// Struct that contains embedded struct and field to same struct.
@@ -975,45 +994,47 @@ func TestDump(t *testing.T) {
 func TestDumpSortedKeys(t *testing.T) {
 	cfg := spew.ConfigState{SortKeys: true}
 	s := cfg.Sdump(map[int]string{1: "1", 3: "3", 2: "2"})
-	expected := `(map[int]string) (len=3) {
-(int) 1: (string) (len=1) "1",
-(int) 2: (string) (len=1) "2",
-(int) 3: (string) (len=1) "3"
-}
-`
+	expected := "(map[int]string) (len=3) {\n(int) 1: (string) (len=1) " +
+		"\"1\",\n(int) 2: (string) (len=1) \"2\",\n(int) 3: (string) " +
+		"(len=1) \"3\"\n" +
+		"}\n"
 	if s != expected {
 		t.Errorf("Sorted keys mismatch:\n  %v %v", s, expected)
 	}
 
 	s = cfg.Sdump(map[stringer]int{"1": 1, "3": 3, "2": 2})
-	expected = `(map[spew_test.stringer]int) (len=3) {
-(spew_test.stringer) (len=1) stringer 1: (int) 1,
-(spew_test.stringer) (len=1) stringer 2: (int) 2,
-(spew_test.stringer) (len=1) stringer 3: (int) 3
-}
-`
+	expected = "(map[spew_test.stringer]int) (len=3) {\n" +
+		"(spew_test.stringer) (len=1) stringer 1: (int) 1,\n" +
+		"(spew_test.stringer) (len=1) stringer 2: (int) 2,\n" +
+		"(spew_test.stringer) (len=1) stringer 3: (int) 3\n" +
+		"}\n"
 	if s != expected {
 		t.Errorf("Sorted keys mismatch:\n  %v %v", s, expected)
 	}
 
 	s = cfg.Sdump(map[pstringer]int{pstringer("1"): 1, pstringer("3"): 3, pstringer("2"): 2})
-	expected = `(map[spew_test.pstringer]int) (len=3) {
-(spew_test.pstringer) (len=1) stringer 1: (int) 1,
-(spew_test.pstringer) (len=1) stringer 2: (int) 2,
-(spew_test.pstringer) (len=1) stringer 3: (int) 3
-}
-`
+	expected = "(map[spew_test.pstringer]int) (len=3) {\n" +
+		"(spew_test.pstringer) (len=1) stringer 1: (int) 1,\n" +
+		"(spew_test.pstringer) (len=1) stringer 2: (int) 2,\n" +
+		"(spew_test.pstringer) (len=1) stringer 3: (int) 3\n" +
+		"}\n"
+	if spew.UnsafeDisabled {
+		expected = "(map[spew_test.pstringer]int) (len=3) {\n" +
+			"(spew_test.pstringer) (len=1) \"1\": (int) 1,\n" +
+			"(spew_test.pstringer) (len=1) \"2\": (int) 2,\n" +
+			"(spew_test.pstringer) (len=1) \"3\": (int) 3\n" +
+			"}\n"
+	}
 	if s != expected {
 		t.Errorf("Sorted keys mismatch:\n  %v %v", s, expected)
 	}
 
 	s = cfg.Sdump(map[customError]int{customError(1): 1, customError(3): 3, customError(2): 2})
-	expected = `(map[spew_test.customError]int) (len=3) {
-(spew_test.customError) error: 1: (int) 1,
-(spew_test.customError) error: 2: (int) 2,
-(spew_test.customError) error: 3: (int) 3
-}
-`
+	expected = "(map[spew_test.customError]int) (len=3) {\n" +
+		"(spew_test.customError) error: 1: (int) 1,\n" +
+		"(spew_test.customError) error: 2: (int) 2,\n" +
+		"(spew_test.customError) error: 3: (int) 3\n" +
+		"}\n"
 	if s != expected {
 		t.Errorf("Sorted keys mismatch:\n  %v %v", s, expected)
 	}

--- a/spew/dumpcgo_test.go
+++ b/spew/dumpcgo_test.go
@@ -25,6 +25,7 @@ package spew_test
 
 import (
 	"fmt"
+
 	"github.com/davecgh/go-spew/spew/testdata"
 )
 

--- a/spew/example_test.go
+++ b/spew/example_test.go
@@ -18,6 +18,7 @@ package spew_test
 
 import (
 	"fmt"
+
 	"github.com/davecgh/go-spew/spew"
 )
 
@@ -41,7 +42,6 @@ func (f Flag) String() string {
 }
 
 type Bar struct {
-	flag Flag
 	data uintptr
 }
 
@@ -74,7 +74,6 @@ func ExampleDump() {
 		}
 
 		type Bar struct {
-			flag Flag
 			data uintptr
 		}
 
@@ -85,7 +84,7 @@ func ExampleDump() {
 	*/
 
 	// Setup some sample data structures for the example.
-	bar := Bar{Flag(flagTwo), uintptr(0)}
+	bar := Bar{uintptr(0)}
 	s1 := Foo{bar, map[interface{}]interface{}{"one": true}}
 	f := Flag(5)
 	b := []byte{
@@ -102,7 +101,6 @@ func ExampleDump() {
 	// Output:
 	// (spew_test.Foo) {
 	//  unexportedField: (spew_test.Bar) {
-	//   flag: (spew_test.Flag) flagTwo,
 	//   data: (uintptr) <nil>
 	//  },
 	//  ExportedField: (map[interface {}]interface {}) (len=1) {
@@ -172,7 +170,7 @@ func ExampleConfigState_Dump() {
 	scs2 := spew.ConfigState{Indent: " "}
 
 	// Setup some sample data structures for the example.
-	bar := Bar{Flag(flagTwo), uintptr(0)}
+	bar := Bar{uintptr(0)}
 	s1 := Foo{bar, map[interface{}]interface{}{"one": true}}
 
 	// Dump using the ConfigState instances.
@@ -182,7 +180,6 @@ func ExampleConfigState_Dump() {
 	// Output:
 	// (spew_test.Foo) {
 	// 	unexportedField: (spew_test.Bar) {
-	// 		flag: (spew_test.Flag) flagTwo,
 	// 		data: (uintptr) <nil>
 	// 	},
 	// 	ExportedField: (map[interface {}]interface {}) (len=1) {
@@ -191,7 +188,6 @@ func ExampleConfigState_Dump() {
 	// }
 	// (spew_test.Foo) {
 	//  unexportedField: (spew_test.Bar) {
-	//   flag: (spew_test.Flag) flagTwo,
 	//   data: (uintptr) <nil>
 	//  },
 	//  ExportedField: (map[interface {}]interface {}) (len=1) {

--- a/spew/format_test.go
+++ b/spew/format_test.go
@@ -530,22 +530,26 @@ func addArrayFormatterTests() {
 	v2Addr := fmt.Sprintf("%p", pv2)
 	pv2Addr := fmt.Sprintf("%p", &pv2)
 	v2t := "[3]spew_test.pstringer"
-	v2s := "[stringer 1 stringer 2 stringer 3]"
+	v2sp := "[stringer 1 stringer 2 stringer 3]"
+	v2s := v2sp
+	if spew.UnsafeDisabled {
+		v2s = "[1 2 3]"
+	}
 	addFormatterTest("%v", v2, v2s)
-	addFormatterTest("%v", pv2, "<*>"+v2s)
-	addFormatterTest("%v", &pv2, "<**>"+v2s)
+	addFormatterTest("%v", pv2, "<*>"+v2sp)
+	addFormatterTest("%v", &pv2, "<**>"+v2sp)
 	addFormatterTest("%+v", nv2, "<nil>")
 	addFormatterTest("%+v", v2, v2s)
-	addFormatterTest("%+v", pv2, "<*>("+v2Addr+")"+v2s)
-	addFormatterTest("%+v", &pv2, "<**>("+pv2Addr+"->"+v2Addr+")"+v2s)
+	addFormatterTest("%+v", pv2, "<*>("+v2Addr+")"+v2sp)
+	addFormatterTest("%+v", &pv2, "<**>("+pv2Addr+"->"+v2Addr+")"+v2sp)
 	addFormatterTest("%+v", nv2, "<nil>")
 	addFormatterTest("%#v", v2, "("+v2t+")"+v2s)
-	addFormatterTest("%#v", pv2, "(*"+v2t+")"+v2s)
-	addFormatterTest("%#v", &pv2, "(**"+v2t+")"+v2s)
+	addFormatterTest("%#v", pv2, "(*"+v2t+")"+v2sp)
+	addFormatterTest("%#v", &pv2, "(**"+v2t+")"+v2sp)
 	addFormatterTest("%#v", nv2, "(*"+v2t+")"+"<nil>")
 	addFormatterTest("%#+v", v2, "("+v2t+")"+v2s)
-	addFormatterTest("%#+v", pv2, "(*"+v2t+")("+v2Addr+")"+v2s)
-	addFormatterTest("%#+v", &pv2, "(**"+v2t+")("+pv2Addr+"->"+v2Addr+")"+v2s)
+	addFormatterTest("%#+v", pv2, "(*"+v2t+")("+v2Addr+")"+v2sp)
+	addFormatterTest("%#+v", &pv2, "(**"+v2t+")("+pv2Addr+"->"+v2Addr+")"+v2sp)
 	addFormatterTest("%#+v", nv2, "(*"+v2t+")"+"<nil>")
 
 	// Array containing interfaces.
@@ -803,6 +807,9 @@ func addMapFormatterTests() {
 	pv2Addr := fmt.Sprintf("%p", &pv2)
 	v2t := "map[spew_test.pstringer]spew_test.pstringer"
 	v2s := "map[stringer one:stringer 1]"
+	if spew.UnsafeDisabled {
+		v2s = "map[one:1]"
+	}
 	addFormatterTest("%v", v2, v2s)
 	addFormatterTest("%v", pv2, "<*>"+v2s)
 	addFormatterTest("%v", &pv2, "<**>"+v2s)
@@ -960,23 +967,34 @@ func addStructFormatterTests() {
 	v3t := "spew_test.s3"
 	v3t2 := "spew_test.pstringer"
 	v3s := "{stringer test stringer test2}"
+	v3sp := v3s
 	v3s2 := "{s:stringer test S:stringer test2}"
+	v3s2p := v3s2
 	v3s3 := "{s:(" + v3t2 + ")stringer test S:(" + v3t2 + ")stringer test2}"
+	v3s3p := v3s3
+	if spew.UnsafeDisabled {
+		v3s = "{test test2}"
+		v3sp = "{test stringer test2}"
+		v3s2 = "{s:test S:test2}"
+		v3s2p = "{s:test S:stringer test2}"
+		v3s3 = "{s:(" + v3t2 + ")test S:(" + v3t2 + ")test2}"
+		v3s3p = "{s:(" + v3t2 + ")test S:(" + v3t2 + ")stringer test2}"
+	}
 	addFormatterTest("%v", v3, v3s)
-	addFormatterTest("%v", pv3, "<*>"+v3s)
-	addFormatterTest("%v", &pv3, "<**>"+v3s)
+	addFormatterTest("%v", pv3, "<*>"+v3sp)
+	addFormatterTest("%v", &pv3, "<**>"+v3sp)
 	addFormatterTest("%+v", nv3, "<nil>")
 	addFormatterTest("%+v", v3, v3s2)
-	addFormatterTest("%+v", pv3, "<*>("+v3Addr+")"+v3s2)
-	addFormatterTest("%+v", &pv3, "<**>("+pv3Addr+"->"+v3Addr+")"+v3s2)
+	addFormatterTest("%+v", pv3, "<*>("+v3Addr+")"+v3s2p)
+	addFormatterTest("%+v", &pv3, "<**>("+pv3Addr+"->"+v3Addr+")"+v3s2p)
 	addFormatterTest("%+v", nv3, "<nil>")
 	addFormatterTest("%#v", v3, "("+v3t+")"+v3s3)
-	addFormatterTest("%#v", pv3, "(*"+v3t+")"+v3s3)
-	addFormatterTest("%#v", &pv3, "(**"+v3t+")"+v3s3)
+	addFormatterTest("%#v", pv3, "(*"+v3t+")"+v3s3p)
+	addFormatterTest("%#v", &pv3, "(**"+v3t+")"+v3s3p)
 	addFormatterTest("%#v", nv3, "(*"+v3t+")"+"<nil>")
 	addFormatterTest("%#+v", v3, "("+v3t+")"+v3s3)
-	addFormatterTest("%#+v", pv3, "(*"+v3t+")("+v3Addr+")"+v3s3)
-	addFormatterTest("%#+v", &pv3, "(**"+v3t+")("+pv3Addr+"->"+v3Addr+")"+v3s3)
+	addFormatterTest("%#+v", pv3, "(*"+v3t+")("+v3Addr+")"+v3s3p)
+	addFormatterTest("%#+v", &pv3, "(**"+v3t+")("+pv3Addr+"->"+v3Addr+")"+v3s3p)
 	addFormatterTest("%#+v", nv3, "(*"+v3t+")"+"<nil>")
 
 	// Struct that contains embedded struct and field to same struct.
@@ -1500,36 +1518,41 @@ func TestPrintSortedKeys(t *testing.T) {
 	s := cfg.Sprint(map[int]string{1: "1", 3: "3", 2: "2"})
 	expected := "map[1:1 2:2 3:3]"
 	if s != expected {
-		t.Errorf("Sorted keys mismatch:\n  %v %v", s, expected)
+		t.Errorf("Sorted keys mismatch 1:\n  %v %v", s, expected)
 	}
 
 	s = cfg.Sprint(map[stringer]int{"1": 1, "3": 3, "2": 2})
 	expected = "map[stringer 1:1 stringer 2:2 stringer 3:3]"
 	if s != expected {
-		t.Errorf("Sorted keys mismatch:\n  %v %v", s, expected)
+		t.Errorf("Sorted keys mismatch 2:\n  %v %v", s, expected)
 	}
 
 	s = cfg.Sprint(map[pstringer]int{pstringer("1"): 1, pstringer("3"): 3, pstringer("2"): 2})
 	expected = "map[stringer 1:1 stringer 2:2 stringer 3:3]"
+	if spew.UnsafeDisabled {
+		expected = "map[1:1 2:2 3:3]"
+	}
 	if s != expected {
-		t.Errorf("Sorted keys mismatch:\n  %v %v", s, expected)
+		t.Errorf("Sorted keys mismatch 3:\n  %v %v", s, expected)
 	}
 
 	s = cfg.Sprint(map[testStruct]int{testStruct{1}: 1, testStruct{3}: 3, testStruct{2}: 2})
 	expected = "map[ts.1:1 ts.2:2 ts.3:3]"
 	if s != expected {
-		t.Errorf("Sorted keys mismatch:\n  %v %v", s, expected)
+		t.Errorf("Sorted keys mismatch 4:\n  %v %v", s, expected)
 	}
 
-	s = cfg.Sprint(map[testStructP]int{testStructP{1}: 1, testStructP{3}: 3, testStructP{2}: 2})
-	expected = "map[ts.1:1 ts.2:2 ts.3:3]"
-	if s != expected {
-		t.Errorf("Sorted keys mismatch:\n  %v %v", s, expected)
+	if !spew.UnsafeDisabled {
+		s = cfg.Sprint(map[testStructP]int{testStructP{1}: 1, testStructP{3}: 3, testStructP{2}: 2})
+		expected = "map[ts.1:1 ts.2:2 ts.3:3]"
+		if s != expected {
+			t.Errorf("Sorted keys mismatch 5:\n  %v %v", s, expected)
+		}
 	}
 
 	s = cfg.Sprint(map[customError]int{customError(1): 1, customError(3): 3, customError(2): 2})
 	expected = "map[error: 1:1 error: 2:2 error: 3:3]"
 	if s != expected {
-		t.Errorf("Sorted keys mismatch:\n  %v %v", s, expected)
+		t.Errorf("Sorted keys mismatch 6:\n  %v %v", s, expected)
 	}
 }

--- a/spew/internal_test.go
+++ b/spew/internal_test.go
@@ -26,7 +26,6 @@ import (
 	"bytes"
 	"reflect"
 	"testing"
-	"unsafe"
 )
 
 // dummyFmtState implements a fake fmt.State to use for testing invalid
@@ -78,74 +77,6 @@ func TestInvalidReflectValue(t *testing.T) {
 	want = "<invalid>"
 	if s != want {
 		t.Errorf("InvalidReflectValue #%d got: %s want: %s", i, s, want)
-	}
-}
-
-// changeKind uses unsafe to intentionally change the kind of a reflect.Value to
-// the maximum kind value which does not exist.  This is needed to test the
-// fallback code which punts to the standard fmt library for new types that
-// might get added to the language.
-func changeKind(v *reflect.Value, readOnly bool) {
-	rvf := (*uintptr)(unsafe.Pointer(uintptr(unsafe.Pointer(v)) + offsetFlag))
-	*rvf = *rvf | ((1<<flagKindWidth - 1) << flagKindShift)
-	if readOnly {
-		*rvf |= flagRO
-	} else {
-		*rvf &= ^uintptr(flagRO)
-	}
-}
-
-// TestAddedReflectValue tests functionaly of the dump and formatter code which
-// falls back to the standard fmt library for new types that might get added to
-// the language.
-func TestAddedReflectValue(t *testing.T) {
-	i := 1
-
-	// Dump using a reflect.Value that is exported.
-	v := reflect.ValueOf(int8(5))
-	changeKind(&v, false)
-	buf := new(bytes.Buffer)
-	d := dumpState{w: buf, cs: &Config}
-	d.dump(v)
-	s := buf.String()
-	want := "(int8) 5"
-	if s != want {
-		t.Errorf("TestAddedReflectValue #%d\n got: %s want: %s", i, s, want)
-	}
-	i++
-
-	// Dump using a reflect.Value that is not exported.
-	changeKind(&v, true)
-	buf.Reset()
-	d.dump(v)
-	s = buf.String()
-	want = "(int8) <int8 Value>"
-	if s != want {
-		t.Errorf("TestAddedReflectValue #%d\n got: %s want: %s", i, s, want)
-	}
-	i++
-
-	// Formatter using a reflect.Value that is exported.
-	changeKind(&v, false)
-	buf2 := new(dummyFmtState)
-	f := formatState{value: v, cs: &Config, fs: buf2}
-	f.format(v)
-	s = buf2.String()
-	want = "5"
-	if s != want {
-		t.Errorf("TestAddedReflectValue #%d got: %s want: %s", i, s, want)
-	}
-	i++
-
-	// Formatter using a reflect.Value that is not exported.
-	changeKind(&v, true)
-	buf2.Reset()
-	f = formatState{value: v, cs: &Config, fs: buf2}
-	f.format(v)
-	s = buf2.String()
-	want = "<int8 Value>"
-	if s != want {
-		t.Errorf("TestAddedReflectValue #%d got: %s want: %s", i, s, want)
 	}
 }
 

--- a/spew/internalunsafe_test.go
+++ b/spew/internalunsafe_test.go
@@ -1,0 +1,101 @@
+// Copyright (c) 2013-2015 Dave Collins <dave@davec.name>
+
+// Permission to use, copy, modify, and distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+// WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+// MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+// ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+// WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+// ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+// OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+// NOTE: Due to the following build constraints, this file will only be compiled
+// when the code is not running on Google App Engine and "-tags disableunsafe"
+// is not added to the go build command line.
+// +build !appengine,!disableunsafe
+
+/*
+This test file is part of the spew package rather than than the spew_test
+package because it needs access to internals to properly test certain cases
+which are not possible via the public interface since they should never happen.
+*/
+
+package spew
+
+import (
+	"bytes"
+	"reflect"
+	"testing"
+	"unsafe"
+)
+
+// changeKind uses unsafe to intentionally change the kind of a reflect.Value to
+// the maximum kind value which does not exist.  This is needed to test the
+// fallback code which punts to the standard fmt library for new types that
+// might get added to the language.
+func changeKind(v *reflect.Value, readOnly bool) {
+	rvf := (*uintptr)(unsafe.Pointer(uintptr(unsafe.Pointer(v)) + offsetFlag))
+	*rvf = *rvf | ((1<<flagKindWidth - 1) << flagKindShift)
+	if readOnly {
+		*rvf |= flagRO
+	} else {
+		*rvf &= ^uintptr(flagRO)
+	}
+}
+
+// TestAddedReflectValue tests functionaly of the dump and formatter code which
+// falls back to the standard fmt library for new types that might get added to
+// the language.
+func TestAddedReflectValue(t *testing.T) {
+	i := 1
+
+	// Dump using a reflect.Value that is exported.
+	v := reflect.ValueOf(int8(5))
+	changeKind(&v, false)
+	buf := new(bytes.Buffer)
+	d := dumpState{w: buf, cs: &Config}
+	d.dump(v)
+	s := buf.String()
+	want := "(int8) 5"
+	if s != want {
+		t.Errorf("TestAddedReflectValue #%d\n got: %s want: %s", i, s, want)
+	}
+	i++
+
+	// Dump using a reflect.Value that is not exported.
+	changeKind(&v, true)
+	buf.Reset()
+	d.dump(v)
+	s = buf.String()
+	want = "(int8) <int8 Value>"
+	if s != want {
+		t.Errorf("TestAddedReflectValue #%d\n got: %s want: %s", i, s, want)
+	}
+	i++
+
+	// Formatter using a reflect.Value that is exported.
+	changeKind(&v, false)
+	buf2 := new(dummyFmtState)
+	f := formatState{value: v, cs: &Config, fs: buf2}
+	f.format(v)
+	s = buf2.String()
+	want = "5"
+	if s != want {
+		t.Errorf("TestAddedReflectValue #%d got: %s want: %s", i, s, want)
+	}
+	i++
+
+	// Formatter using a reflect.Value that is not exported.
+	changeKind(&v, true)
+	buf2.Reset()
+	f = formatState{value: v, cs: &Config, fs: buf2}
+	f.format(v)
+	s = buf2.String()
+	want = "<int8 Value>"
+	if s != want {
+		t.Errorf("TestAddedReflectValue #%d got: %s want: %s", i, s, want)
+	}
+}

--- a/spew/spew_test.go
+++ b/spew/spew_test.go
@@ -19,10 +19,11 @@ package spew_test
 import (
 	"bytes"
 	"fmt"
-	"github.com/davecgh/go-spew/spew"
 	"io/ioutil"
 	"os"
 	"testing"
+
+	"github.com/davecgh/go-spew/spew"
 )
 
 // spewFunc is used to identify which public function of the spew package or


### PR DESCRIPTION
This pull request adds support for compiling spew without the unsafe package.  When compiled without the unsafe package, some of the more advanced features such as invoking stringers on pointers from non-pointer
variables and unexported struct fields are not available.

By default, spew will be compiled in the limited mode for Google App Engine since the unsafe package is not available there.  Additionally, spew can be compiled without the unsafe package manually by specifying
the `disableunsafe` build tag.

Finally, a new package-level constant named "UnsafeDisabled" has been exposed which can be used to programmatically determine if spew was compiled with access to the unsafe package.