### PR TITLE
Disable unsafe for GopherJS compiler.

### DIFF
--- a/spew/bypass.go
+++ b/spew/bypass.go
@@ -13,8 +13,8 @@
 // OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 // NOTE: Due to the following build constraints, this file will only be compiled
-// when the code is not running on Google App Engine and "-tags disableunsafe"
-// is not added to the go build command line.
+// when the code is not running on Google App Engine, compiled by GopherJS, and
+// "-tags disableunsafe" is not added to the go build command line.
 // +build !appengine,!disableunsafe,!js
 
 package spew

--- a/spew/bypass.go
+++ b/spew/bypass.go
@@ -15,7 +15,7 @@
 // NOTE: Due to the following build constraints, this file will only be compiled
 // when the code is not running on Google App Engine and "-tags disableunsafe"
 // is not added to the go build command line.
-// +build !appengine,!disableunsafe
+// +build !appengine,!disableunsafe,!js
 
 package spew
 

--- a/spew/bypasssafe.go
+++ b/spew/bypasssafe.go
@@ -13,8 +13,8 @@
 // OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 // NOTE: Due to the following build constraints, this file will only be compiled
-// when either the code is running on Google App Engine or "-tags disableunsafe"
-// is added to the go build command line.
+// when the code is running on Google App Engine, compiled by GopherJS, or
+// "-tags disableunsafe" is added to the go build command line.
 // +build appengine disableunsafe js
 
 package spew

--- a/spew/bypasssafe.go
+++ b/spew/bypasssafe.go
@@ -15,7 +15,7 @@
 // NOTE: Due to the following build constraints, this file will only be compiled
 // when either the code is running on Google App Engine or "-tags disableunsafe"
 // is added to the go build command line.
-// +build appengine disableunsafe
+// +build appengine disableunsafe js
 
 package spew
 

--- a/spew/internalunsafe_test.go
+++ b/spew/internalunsafe_test.go
@@ -13,8 +13,8 @@
 // OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 // NOTE: Due to the following build constraints, this file will only be compiled
-// when the code is not running on Google App Engine and "-tags disableunsafe"
-// is not added to the go build command line.
+// when the code is not running on Google App Engine, compiled by GopherJS, and
+// "-tags disableunsafe" is not added to the go build command line.
 // +build !appengine,!disableunsafe,!js
 
 /*

--- a/spew/internalunsafe_test.go
+++ b/spew/internalunsafe_test.go
@@ -15,7 +15,7 @@
 // NOTE: Due to the following build constraints, this file will only be compiled
 // when the code is not running on Google App Engine and "-tags disableunsafe"
 // is not added to the go build command line.
-// +build !appengine,!disableunsafe
+// +build !appengine,!disableunsafe,!js
 
 /*
 This test file is part of the spew package rather than than the spew_test


### PR DESCRIPTION
This simple commit makes go-spew work with the GopherJS compiler.
