### PR TITLE
Deprecate "disableunsafe" tag in favor of "safe".

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ go:
 install:
     - go get -v golang.org/x/tools/cmd/cover
 script:
-    - go test -v -tags=disableunsafe ./spew
+    - go test -v -tags=safe ./spew
     - go test -v -tags=testcgo ./spew -covermode=count -coverprofile=profile.cov
 after_success:
     - go get -v github.com/mattn/goveralls

--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ options. See the ConfigState documentation for more details.
 	which only accept pointer receivers from non-pointer variables.  This option
 	relies on access to the unsafe package, so it will not have any effect when
 	running in environments without access to the unsafe package such as Google
-	App Engine or with the "disableunsafe" build tag specified.
+	App Engine or with the "safe" build tag specified.
 	Pointer method invocation is enabled by default.
 
 * ContinueOnMethod
@@ -185,9 +185,9 @@ options. See the ConfigState documentation for more details.
 This package relies on the unsafe package to perform some of the more advanced
 features, however it also supports a "limited" mode which allows it to work in
 environments where the unsafe package is not available.  By default, it will
-operate in this mode on Google App Engine.  The "disableunsafe" build tag may
-also be specified to force the package to build without using the unsafe
-package.
+operate in this mode on Google App Engine and when compiled with GopherJS.  The
+"safe" build tag may also be specified to force the package to build without
+using the unsafe package.
 
 ## License
 

--- a/spew/bypass.go
+++ b/spew/bypass.go
@@ -14,8 +14,9 @@
 
 // NOTE: Due to the following build constraints, this file will only be compiled
 // when the code is not running on Google App Engine, compiled by GopherJS, and
-// "-tags disableunsafe" is not added to the go build command line.
-// +build !appengine,!disableunsafe,!js
+// "-tags safe" is not added to the go build command line.  The "disableunsafe"
+// tag is deprecated and thus should not be used.
+// +build !js,!appengine,!safe,!disableunsafe
 
 package spew
 

--- a/spew/bypasssafe.go
+++ b/spew/bypasssafe.go
@@ -14,8 +14,9 @@
 
 // NOTE: Due to the following build constraints, this file will only be compiled
 // when the code is running on Google App Engine, compiled by GopherJS, or
-// "-tags disableunsafe" is added to the go build command line.
-// +build appengine disableunsafe js
+// "-tags safe" is added to the go build command line.  The "disableunsafe"
+// tag is deprecated and thus should not be used.
+// +build js appengine safe disableunsafe
 
 package spew
 

--- a/spew/config.go
+++ b/spew/config.go
@@ -64,7 +64,7 @@ type ConfigState struct {
 	// inside these interface methods.  As a result, this option relies on
 	// access to the unsafe package, so it will not have any effect when
 	// running in environments without access to the unsafe package such as
-	// Google App Engine or with the "disableunsafe" build tag specified.
+	// Google App Engine or with the "safe" build tag specified.
 	DisablePointerMethods bool
 
 	// ContinueOnMethod specifies whether or not recursion should continue once

--- a/spew/internalunsafe_test.go
+++ b/spew/internalunsafe_test.go
@@ -14,8 +14,9 @@
 
 // NOTE: Due to the following build constraints, this file will only be compiled
 // when the code is not running on Google App Engine, compiled by GopherJS, and
-// "-tags disableunsafe" is not added to the go build command line.
-// +build !appengine,!disableunsafe,!js
+// "-tags safe" is not added to the go build command line.  The "disableunsafe"
+// tag is deprecated and thus should not be used.
+// +build !js,!appengine,!safe,!disableunsafe
 
 /*
 This test file is part of the spew package rather than than the spew_test


### PR DESCRIPTION
This adds a new build tag named `safe` which serves the exact same purpose as the current `disableunsafe` tag.  This is being done, as recommended by @shurcooL, since it is emerging as the standard way to do
it in several high profile packages, it mirrors the `unsafe` package nicely, it is shorter, and users generally seem to prefer it.

However, to avoid breaking existing infrastructure, the `disableunsafe` tag is still available and simply is being deprecated.