### PR TITLE
Add options to disable printing of type and length

### DIFF
--- a/spew/config.go
+++ b/spew/config.go
@@ -76,6 +76,13 @@ type ConfigState struct {
 	// data structures in tests.
 	DisableCapacities bool
 
+	// DisableTypes specifies whether to disable the printing of types.
+	DisableTypes bool
+
+	// DisableLengths specifies whether to disable the printing of lengths.
+	// This also disables the printing of capacities.
+	DisableLengths bool
+
 	// ContinueOnMethod specifies whether or not recursion should continue once
 	// a custom error or Stringer interface is invoked.  The default, false,
 	// means it will print the results of invoking the custom error or Stringer

--- a/spew/doc.go
+++ b/spew/doc.go
@@ -100,6 +100,13 @@ The following configuration options are available:
 		capacities for arrays, slices, maps and channels. This is useful when
 		diffing data structures in tests.
 
+	* DisableTypes
+		DisableTypes specifies whether to disable the printing of types.
+
+	* DisableLengths
+		DisableLengths specifies whether to disable the printing of lengths.
+		This also disables the printing of capacities.
+
 	* ContinueOnMethod
 		Enables recursion into types after invoking error and Stringer interface
 		methods. Recursion after method invocation is disabled by default.

--- a/spew/dump.go
+++ b/spew/dump.go
@@ -266,37 +266,41 @@ func (d *dumpState) dump(v reflect.Value) {
 	// Print type information unless already handled elsewhere.
 	if !d.ignoreNextType {
 		d.indent()
-		d.w.Write(openParenBytes)
-		d.w.Write([]byte(v.Type().String()))
-		d.w.Write(closeParenBytes)
-		d.w.Write(spaceBytes)
+		if !d.cs.DisableTypes {
+			d.w.Write(openParenBytes)
+			d.w.Write([]byte(v.Type().String()))
+			d.w.Write(closeParenBytes)
+			d.w.Write(spaceBytes)
+		}
 	}
 	d.ignoreNextType = false
 
 	// Display length and capacity if the built-in len and cap functions
 	// work with the value's kind and the len/cap itself is non-zero.
-	valueLen, valueCap := 0, 0
-	switch v.Kind() {
-	case reflect.Array, reflect.Slice, reflect.Chan:
-		valueLen, valueCap = v.Len(), v.Cap()
-	case reflect.Map, reflect.String:
-		valueLen = v.Len()
-	}
-	if valueLen != 0 || !d.cs.DisableCapacities && valueCap != 0 {
-		d.w.Write(openParenBytes)
-		if valueLen != 0 {
-			d.w.Write(lenEqualsBytes)
-			printInt(d.w, int64(valueLen), 10)
+	if !d.cs.DisableLengths {
+		valueLen, valueCap := 0, 0
+		switch v.Kind() {
+		case reflect.Array, reflect.Slice, reflect.Chan:
+			valueLen, valueCap = v.Len(), v.Cap()
+		case reflect.Map, reflect.String:
+			valueLen = v.Len()
 		}
-		if !d.cs.DisableCapacities && valueCap != 0 {
+		if valueLen != 0 || !d.cs.DisableCapacities && valueCap != 0 {
+			d.w.Write(openParenBytes)
 			if valueLen != 0 {
-				d.w.Write(spaceBytes)
+				d.w.Write(lenEqualsBytes)
+				printInt(d.w, int64(valueLen), 10)
 			}
-			d.w.Write(capEqualsBytes)
-			printInt(d.w, int64(valueCap), 10)
+			if !d.cs.DisableCapacities && valueCap != 0 {
+				if valueLen != 0 {
+					d.w.Write(spaceBytes)
+				}
+				d.w.Write(capEqualsBytes)
+				printInt(d.w, int64(valueCap), 10)
+			}
+			d.w.Write(closeParenBytes)
+			d.w.Write(spaceBytes)
 		}
-		d.w.Write(closeParenBytes)
-		d.w.Write(spaceBytes)
 	}
 
 	// Call Stringer/error interfaces if they exist and the handle methods flag


### PR DESCRIPTION
Disabling types/lengths leads to more concise, human-readable, multi-line output.

I've attempted to add tests, but they are failing to run with:
```
~/p/g/s/g/k/go-spew $ go test -v -tags testcgo ./spew                                                          ⏎ master ✱
# github.com/kibra/go-spew/spew_test
spew/common_test.go:144: undefined: spew.SortValues
```

I'll take a look tomorrow.

Addresses: https://github.com/davecgh/go-spew/issues/19

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/davecgh/go-spew/58)
<!-- Reviewable:end -->
