### PR TITLE
Add config options AlwaysIncludeTrailingComma, DisableNilValues

### DIFF
--- a/spew/config.go
+++ b/spew/config.go
@@ -67,6 +67,12 @@ type ConfigState struct {
 	// Google App Engine or with the "safe" build tag specified.
 	DisablePointerMethods bool
 
+	// DisableNilValues specifies whether or not to include nil fields. This is
+	// useful in tests that rely on "golden" test data: Often one adds a new,
+	// optional field to a struct, and it's onerous to update all test data
+	// to reflect this field, which would now be nil everywhere.
+	DisableNilValues bool
+
 	// DisablePointerAddresses specifies whether to disable the printing of
 	// pointer addresses. This is useful when diffing data structures in tests.
 	DisablePointerAddresses bool

--- a/spew/config.go
+++ b/spew/config.go
@@ -76,6 +76,11 @@ type ConfigState struct {
 	// data structures in tests.
 	DisableCapacities bool
 
+	// AlwaysIncludeTrailingComma specifies whether to always include a trailing
+	// comma, Go-style. This is useful to avoid false positives when diffing data
+	// structures in tests.
+	AlwaysIncludeTrailingComma bool
+
 	// ContinueOnMethod specifies whether or not recursion should continue once
 	// a custom error or Stringer interface is invoked.  The default, false,
 	// means it will print the results of invoking the custom error or Stringer

--- a/spew/dump.go
+++ b/spew/dump.go
@@ -236,11 +236,7 @@ func (d *dumpState) dumpSlice(v reflect.Value) {
 	// Recursively call dump for each item.
 	for i := 0; i < numEntries; i++ {
 		d.dump(d.unpackValue(v.Index(i)))
-		if i < (numEntries - 1) {
-			d.w.Write(commaNewlineBytes)
-		} else {
-			d.w.Write(newlineBytes)
-		}
+		d.writeComma(i < (numEntries - 1))
 	}
 }
 
@@ -392,11 +388,7 @@ func (d *dumpState) dump(v reflect.Value) {
 				d.w.Write(colonSpaceBytes)
 				d.ignoreNextIndent = true
 				d.dump(d.unpackValue(v.MapIndex(key)))
-				if i < (numEntries - 1) {
-					d.w.Write(commaNewlineBytes)
-				} else {
-					d.w.Write(newlineBytes)
-				}
+				d.writeComma(i < (numEntries - 1))
 			}
 		}
 		d.depth--
@@ -419,11 +411,7 @@ func (d *dumpState) dump(v reflect.Value) {
 				d.w.Write(colonSpaceBytes)
 				d.ignoreNextIndent = true
 				d.dump(d.unpackValue(v.Field(i)))
-				if i < (numFields - 1) {
-					d.w.Write(commaNewlineBytes)
-				} else {
-					d.w.Write(newlineBytes)
-				}
+				d.writeComma(i < (numFields - 1))
 			}
 		}
 		d.depth--
@@ -445,6 +433,16 @@ func (d *dumpState) dump(v reflect.Value) {
 		} else {
 			fmt.Fprintf(d.w, "%v", v.String())
 		}
+	}
+}
+
+// writeComma emits a comma if hasMoreElements is true, or if trailing commas
+// are always enabled.
+func (d *dumpState) writeComma(hasMoreElements bool) {
+	if hasMoreElements || d.cs.AlwaysIncludeTrailingComma {
+		d.w.Write(commaNewlineBytes)
+	} else {
+		d.w.Write(newlineBytes)
 	}
 }
 

--- a/spew/dump.go
+++ b/spew/dump.go
@@ -234,10 +234,16 @@ func (d *dumpState) dumpSlice(v reflect.Value) {
 	}
 
 	// Recursively call dump for each item.
+	l := list{dumpState: d}
 	for i := 0; i < numEntries; i++ {
-		d.dump(d.unpackValue(v.Index(i)))
-		d.writeComma(i < (numEntries - 1))
+		entryVal := d.unpackValue(v.Index(i))
+		if !d.filterValue(entryVal) {
+			continue
+		}
+		l.beginEntry()
+		d.dump(entryVal)
 	}
+	l.end()
 }
 
 // dump is the main workhorse for dumping a value.  It uses the passed reflect
@@ -378,18 +384,23 @@ func (d *dumpState) dump(v reflect.Value) {
 			d.indent()
 			d.w.Write(maxNewlineBytes)
 		} else {
-			numEntries := v.Len()
 			keys := v.MapKeys()
 			if d.cs.SortKeys {
 				sortValues(keys, d.cs)
 			}
-			for i, key := range keys {
+			l := list{dumpState: d}
+			for _, key := range keys {
+				mapValue := d.unpackValue(v.MapIndex(key))
+				if !d.filterValue(mapValue) {
+					continue
+				}
+				l.beginEntry()
 				d.dump(d.unpackValue(key))
 				d.w.Write(colonSpaceBytes)
 				d.ignoreNextIndent = true
-				d.dump(d.unpackValue(v.MapIndex(key)))
-				d.writeComma(i < (numEntries - 1))
+				d.dump(mapValue)
 			}
+			l.end()
 		}
 		d.depth--
 		d.indent()
@@ -404,15 +415,20 @@ func (d *dumpState) dump(v reflect.Value) {
 		} else {
 			vt := v.Type()
 			numFields := v.NumField()
+			l := list{dumpState: d, indented: true}
 			for i := 0; i < numFields; i++ {
-				d.indent()
+				fieldValue := d.unpackValue(v.Field(i))
+				if !d.filterValue(fieldValue) {
+					continue
+				}
+				l.beginEntry()
 				vtf := vt.Field(i)
 				d.w.Write([]byte(vtf.Name))
 				d.w.Write(colonSpaceBytes)
 				d.ignoreNextIndent = true
-				d.dump(d.unpackValue(v.Field(i)))
-				d.writeComma(i < (numFields - 1))
+				d.dump(fieldValue)
 			}
+			l.end()
 		}
 		d.depth--
 		d.indent()
@@ -436,9 +452,9 @@ func (d *dumpState) dump(v reflect.Value) {
 	}
 }
 
-// writeComma emits a comma if hasMoreElements is true, or if trailing commas
-// are always enabled.
-func (d *dumpState) writeComma(hasMoreElements bool) {
+// writeDelimiter emits a comma if hasMoreElements is true, or if trailing
+// commas are always enabled.
+func (d *dumpState) writeDelimiter(hasMoreElements bool) {
 	if hasMoreElements || d.cs.AlwaysIncludeTrailingComma {
 		d.w.Write(commaNewlineBytes)
 	} else {
@@ -446,15 +462,57 @@ func (d *dumpState) writeComma(hasMoreElements bool) {
 	}
 }
 
+// filterValue returns true if a value should be dumped.
+func (d *dumpState) filterValue(value reflect.Value) bool {
+	if !d.cs.DisableNilValues {
+		return true
+	}
+	return !isNil(value)
+}
+
+// list is a small helper to write lists and ensure that each item is
+// correctly delimited, and that nothing is emitted if no entires were added.
+type list struct {
+	count    int
+	indented bool
+	*dumpState
+}
+
+func (l *list) beginEntry() {
+	if l.count > 0 {
+		l.writeDelimiter(true)
+	}
+	l.count++
+	if l.indented {
+		l.indent()
+	}
+}
+
+func (l *list) end() {
+	if l.count > 0 {
+		l.writeDelimiter(false)
+	}
+}
+
+func isNil(v reflect.Value) bool {
+	switch v.Kind() {
+	case reflect.Interface, reflect.Map, reflect.Slice, reflect.Ptr:
+		return v.IsNil()
+	}
+	return false
+}
+
 // fdump is a helper function to consolidate the logic from the various public
 // methods which take varying writers and config states.
 func fdump(cs *ConfigState, w io.Writer, a ...interface{}) {
 	for _, arg := range a {
 		if arg == nil {
-			w.Write(interfaceBytes)
-			w.Write(spaceBytes)
-			w.Write(nilAngleBytes)
-			w.Write(newlineBytes)
+			if !cs.DisableNilValues {
+				w.Write(interfaceBytes)
+				w.Write(spaceBytes)
+				w.Write(nilAngleBytes)
+				w.Write(newlineBytes)
+			}
 			continue
 		}
 

--- a/spew/spew_test.go
+++ b/spew/spew_test.go
@@ -132,6 +132,7 @@ func initSpewTests() {
 	scsContinue := &spew.ConfigState{Indent: " ", ContinueOnMethod: true}
 	scsNoPtrAddr := &spew.ConfigState{DisablePointerAddresses: true}
 	scsNoCap := &spew.ConfigState{DisableCapacities: true}
+	scsTrailingComma := &spew.ConfigState{Indent: " ", AlwaysIncludeTrailingComma: true}
 
 	// Variables for tests on types which implement Stringer interface with and
 	// without a pointer receiver.
@@ -153,6 +154,12 @@ func initSpewTests() {
 	}
 	dt := depthTester{indirCir1{nil}, [1]string{"arr"}, []string{"slice"},
 		map[string]int{"one": 1}}
+
+	// commatester is to test trailing commas
+	type commaTester struct {
+		slice []interface{}
+		m     map[string]int
+	}
 
 	// Variable for tests on types which implement error interface.
 	te := customError(10)
@@ -203,6 +210,22 @@ func initSpewTests() {
 		{scsNoPtrAddr, fCSSdump, "", tptr, "(*spew_test.ptrTester)({\ns: (*struct {})({\n})\n})\n"},
 		{scsNoCap, fCSSdump, "", make([]string, 0, 10), "([]string) {\n}\n"},
 		{scsNoCap, fCSSdump, "", make([]string, 1, 10), "([]string) (len=1) {\n(string) \"\"\n}\n"},
+		{scsTrailingComma, fCSFdump, "", commaTester{
+			slice: []interface{}{
+				map[string]int{"one": 1},
+			},
+			m: map[string]int{"one": 1},
+		},
+			"(spew_test.commaTester) {\n" +
+				" slice: ([]interface {}) (len=1 cap=1) {\n" +
+				"  (map[string]int) (len=1) {\n" +
+				"   (string) (len=3) \"one\": (int) 1,\n" +
+				"  },\n" +
+				" },\n" +
+				" m: (map[string]int) (len=1) {\n" +
+				"  (string) (len=3) \"one\": (int) 1,\n" +
+				" },\n" +
+				"}\n"},
 	}
 }
 

--- a/spew/spew_test.go
+++ b/spew/spew_test.go
@@ -133,6 +133,7 @@ func initSpewTests() {
 	scsNoPtrAddr := &spew.ConfigState{DisablePointerAddresses: true}
 	scsNoCap := &spew.ConfigState{DisableCapacities: true}
 	scsTrailingComma := &spew.ConfigState{Indent: " ", AlwaysIncludeTrailingComma: true}
+	scsNoNils := &spew.ConfigState{Indent: " ", DisableNilValues: true}
 
 	// Variables for tests on types which implement Stringer interface with and
 	// without a pointer receiver.
@@ -143,6 +144,17 @@ func initSpewTests() {
 		s *struct{}
 	}
 	tptr := &ptrTester{s: &struct{}{}}
+
+	type testIntf interface {
+		TestyTesty()
+	}
+
+	type nilTester struct {
+		s     *struct{}
+		slice []interface{}
+		m     map[string]interface{}
+		intf  testIntf
+	}
 
 	// depthTester is used to test max depth handling for structs, array, slices
 	// and maps.
@@ -225,6 +237,15 @@ func initSpewTests() {
 				" m: (map[string]int) (len=1) {\n" +
 				"  (string) (len=3) \"one\": (int) 1,\n" +
 				" },\n" +
+				"}\n"},
+		{scsNoNils, fCSSdump, "", nilTester{}, "(spew_test.nilTester) {\n}\n"},
+		{scsNoNils, fCSSdump, "", nilTester{
+			slice: []interface{}{nil, "foo"},
+		},
+			"(spew_test.nilTester) {\n" +
+				" slice: ([]interface {}) (len=2 cap=2) {\n" +
+				"  (string) (len=3) \"foo\"\n" +
+				" }\n" +
 				"}\n"},
 	}
 }


### PR DESCRIPTION
Adds config option `AlwaysIncludeTrailingComma`, which forces the writing of commas in arrays/slices/maps. Useful in tests to avoid false positives when diffing. This is a prerequisite to resolving [this Testify issue](https://github.com/stretchr/testify/issues/288).

Building on that commit is a new config option `DisableNilValues`. Background: We have a bunch of tests that use Spew to generate "golden" test data. This is great, but often one adds a new, optional field to a struct that's part of this data, and suddenly all the test data is broken because the new filed is `nil` everywhere. It's onerous to update all test data for such zero-value fields. This fixes that.