### PR TITLE
Fix ISC License text

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -2,7 +2,7 @@ ISC License
 
 Copyright (c) 2012-2016 Dave Collins <dave@davec.name>
 
-Permission to use, copy, modify, and distribute this software for any
+Permission to use, copy, modify, and/or distribute this software for any
 purpose with or without fee is hereby granted, provided that the above
 copyright notice and this permission notice appear in all copies.
 


### PR DESCRIPTION
Hi, I'm sending this tiny PR to fix the 'and/or' wording in the ISC license text, which helps when trying to match the package license with libraries like `github.com/ryanuber/go-license`