### PR TITLE
Added a spew tag name with a very basic implementation

### DIFF
--- a/spew/dump.go
+++ b/spew/dump.go
@@ -415,6 +415,11 @@ func (d *dumpState) dump(v reflect.Value) {
 			for i := 0; i < numFields; i++ {
 				d.indent()
 				vtf := vt.Field(i)
+				spewTag := vtf.Tag.Get("spew")
+				switch spewTag {
+				case "-":
+					continue
+				}
 				d.w.Write([]byte(vtf.Name))
 				d.w.Write(colonSpaceBytes)
 				d.ignoreNextIndent = true


### PR DESCRIPTION
I am opening this PR as a suggestion to add the ability to remove some fields from being printed. If this already exists, forgive me for not having noticed it.

The usage would be 
```golang
type AStruct struct {
    Field int `spew:"-"`
}
```
and the field would be omitted.

The implementation is basic and dirty, but let me know if you'd consider it, we can make it pretty.