### PR TITLE
Ignore fields using a tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ import (
     "html"
     "net/http"
 
-    "github.com/davecgh/go-spew/spew"
+    "github.com/coreyog/go-spew/spew"
 )
 
 func handler(w http.ResponseWriter, r *http.Request) {

--- a/spew/common_test.go
+++ b/spew/common_test.go
@@ -21,7 +21,7 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/davecgh/go-spew/spew"
+	"github.com/coreyog/go-spew/spew"
 )
 
 // custom type to test Stinger interface on non-pointer receiver.

--- a/spew/common_test.go
+++ b/spew/common_test.go
@@ -21,7 +21,7 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/coreyog/go-spew/spew"
+	"github.com/davecgh/go-spew/spew"
 )
 
 // custom type to test Stinger interface on non-pointer receiver.

--- a/spew/dump.go
+++ b/spew/dump.go
@@ -413,12 +413,12 @@ func (d *dumpState) dump(v reflect.Value) {
 			vt := v.Type()
 			numFields := v.NumField()
 			for i := 0; i < numFields; i++ {
-				d.indent()
 				vtf := vt.Field(i)
 				tag := vtf.Tag.Get("spew")
 				if tag == "-" {
 					continue
 				}
+				d.indent()
 				d.w.Write([]byte(vtf.Name))
 				d.w.Write(colonSpaceBytes)
 				d.ignoreNextIndent = true

--- a/spew/dump.go
+++ b/spew/dump.go
@@ -415,11 +415,24 @@ func (d *dumpState) dump(v reflect.Value) {
 			for i := 0; i < numFields; i++ {
 				d.indent()
 				vtf := vt.Field(i)
+				tag := vtf.Tag.Get("spew")
+				if tag == "-" {
+					continue
+				}
 				d.w.Write([]byte(vtf.Name))
 				d.w.Write(colonSpaceBytes)
 				d.ignoreNextIndent = true
 				d.dump(d.unpackValue(v.Field(i)))
-				if i < (numFields - 1) {
+
+				hasAnotherFieldToWrite := false
+				for j := i + 1; j < numFields; j++ {
+					vtf = vt.Field(j)
+					tag = vtf.Tag.Get("spew")
+					if tag != "-" {
+						hasAnotherFieldToWrite = true
+					}
+				}
+				if i < (numFields-1) && hasAnotherFieldToWrite {
 					d.w.Write(commaNewlineBytes)
 				} else {
 					d.w.Write(newlineBytes)

--- a/spew/dump_test.go
+++ b/spew/dump_test.go
@@ -67,7 +67,7 @@ import (
 	"testing"
 	"unsafe"
 
-	"github.com/coreyog/go-spew/spew"
+	"github.com/davecgh/go-spew/spew"
 )
 
 // dumpTest is used to describe a test to be performed against the Dump method.

--- a/spew/dump_test.go
+++ b/spew/dump_test.go
@@ -67,7 +67,7 @@ import (
 	"testing"
 	"unsafe"
 
-	"github.com/davecgh/go-spew/spew"
+	"github.com/coreyog/go-spew/spew"
 )
 
 // dumpTest is used to describe a test to be performed against the Dump method.

--- a/spew/dumpcgo_test.go
+++ b/spew/dumpcgo_test.go
@@ -26,7 +26,7 @@ package spew_test
 import (
 	"fmt"
 
-	"github.com/coreyog/go-spew/spew/testdata"
+	"github.com/davecgh/go-spew/spew/testdata"
 )
 
 func addCgoDumpTests() {

--- a/spew/dumpcgo_test.go
+++ b/spew/dumpcgo_test.go
@@ -26,7 +26,7 @@ package spew_test
 import (
 	"fmt"
 
-	"github.com/davecgh/go-spew/spew/testdata"
+	"github.com/coreyog/go-spew/spew/testdata"
 )
 
 func addCgoDumpTests() {

--- a/spew/example_test.go
+++ b/spew/example_test.go
@@ -19,7 +19,7 @@ package spew_test
 import (
 	"fmt"
 
-	"github.com/coreyog/go-spew/spew"
+	"github.com/davecgh/go-spew/spew"
 )
 
 type Flag int

--- a/spew/example_test.go
+++ b/spew/example_test.go
@@ -19,7 +19,7 @@ package spew_test
 import (
 	"fmt"
 
-	"github.com/davecgh/go-spew/spew"
+	"github.com/coreyog/go-spew/spew"
 )
 
 type Flag int

--- a/spew/format_test.go
+++ b/spew/format_test.go
@@ -72,7 +72,7 @@ import (
 	"testing"
 	"unsafe"
 
-	"github.com/davecgh/go-spew/spew"
+	"github.com/coreyog/go-spew/spew"
 )
 
 // formatterTest is used to describe a test to be performed against NewFormatter.

--- a/spew/format_test.go
+++ b/spew/format_test.go
@@ -72,7 +72,7 @@ import (
 	"testing"
 	"unsafe"
 
-	"github.com/coreyog/go-spew/spew"
+	"github.com/davecgh/go-spew/spew"
 )
 
 // formatterTest is used to describe a test to be performed against NewFormatter.

--- a/spew/spew_test.go
+++ b/spew/spew_test.go
@@ -154,6 +154,13 @@ func initSpewTests() {
 	dt := depthTester{indirCir1{nil}, [1]string{"arr"}, []string{"slice"},
 		map[string]int{"one": 1}}
 
+	type ignoreTester struct {
+		visible   bool
+		invisible bool `spew:"-"`
+	}
+
+	it := ignoreTester{true, false}
+
 	// Variable for tests on types which implement error interface.
 	te := customError(10)
 
@@ -179,6 +186,8 @@ func initSpewTests() {
 		{scsDefault, fSprint, "", complex(-1, -2), "(-1-2i)"},
 		{scsDefault, fSprintf, "%v", complex(float32(-3), -4), "(-3-4i)"},
 		{scsDefault, fSprintln, "", complex(float64(-5), -6), "(-5-6i)\n"},
+		{scsDefault, fCSFdump, "", it, "(spew_test.ignoreTester) {\n" +
+			" visible: (bool) true\n }\n"},
 		{scsNoMethods, fCSFprint, "", ts, "test"},
 		{scsNoMethods, fCSFprint, "", &ts, "<*>test"},
 		{scsNoMethods, fCSFprint, "", tps, "test"},

--- a/spew/spew_test.go
+++ b/spew/spew_test.go
@@ -23,7 +23,7 @@ import (
 	"os"
 	"testing"
 
-	"github.com/coreyog/go-spew/spew"
+	"github.com/davecgh/go-spew/spew"
 )
 
 // spewFunc is used to identify which public function of the spew package or

--- a/spew/spew_test.go
+++ b/spew/spew_test.go
@@ -23,7 +23,7 @@ import (
 	"os"
 	"testing"
 
-	"github.com/davecgh/go-spew/spew"
+	"github.com/coreyog/go-spew/spew"
 )
 
 // spewFunc is used to identify which public function of the spew package or

--- a/spew/spew_test.go
+++ b/spew/spew_test.go
@@ -23,7 +23,7 @@ import (
 	"os"
 	"testing"
 
-	"github.com/davecgh/go-spew/spew"
+	"github.com/coreyog/go-spew/spew"
 )
 
 // spewFunc is used to identify which public function of the spew package or
@@ -187,7 +187,7 @@ func initSpewTests() {
 		{scsDefault, fSprintf, "%v", complex(float32(-3), -4), "(-3-4i)"},
 		{scsDefault, fSprintln, "", complex(float64(-5), -6), "(-5-6i)\n"},
 		{scsDefault, fCSFdump, "", it, "(spew_test.ignoreTester) {\n" +
-			" visible: (bool) true\n }\n"},
+			" visible: (bool) true\n}\n"},
 		{scsNoMethods, fCSFprint, "", ts, "test"},
 		{scsNoMethods, fCSFprint, "", &ts, "<*>test"},
 		{scsNoMethods, fCSFprint, "", tps, "test"},


### PR DESCRIPTION
Fields of structs tagged with `spew:"-"` will not be printed. Includes a simple test.