### PR TITLE
ConfigState: Create 'DisableLengths' option

### DIFF
--- a/spew/config.go
+++ b/spew/config.go
@@ -76,6 +76,10 @@ type ConfigState struct {
 	// data structures in tests.
 	DisableCapacities bool
 
+	// DisableLengths specifies whether to disable the printing of lengths
+	// for strings, arrays, slices, maps and channels.
+	DisableLengths bool
+
 	// ContinueOnMethod specifies whether or not recursion should continue once
 	// a custom error or Stringer interface is invoked.  The default, false,
 	// means it will print the results of invoking the custom error or Stringer

--- a/spew/dump.go
+++ b/spew/dump.go
@@ -275,28 +275,30 @@ func (d *dumpState) dump(v reflect.Value) {
 
 	// Display length and capacity if the built-in len and cap functions
 	// work with the value's kind and the len/cap itself is non-zero.
-	valueLen, valueCap := 0, 0
-	switch v.Kind() {
-	case reflect.Array, reflect.Slice, reflect.Chan:
-		valueLen, valueCap = v.Len(), v.Cap()
-	case reflect.Map, reflect.String:
-		valueLen = v.Len()
-	}
-	if valueLen != 0 || !d.cs.DisableCapacities && valueCap != 0 {
-		d.w.Write(openParenBytes)
-		if valueLen != 0 {
-			d.w.Write(lenEqualsBytes)
-			printInt(d.w, int64(valueLen), 10)
+	if !d.cs.DisableLengths {
+		valueLen, valueCap := 0, 0
+		switch v.Kind() {
+		case reflect.Array, reflect.Slice, reflect.Chan:
+			valueLen, valueCap = v.Len(), v.Cap()
+		case reflect.Map, reflect.String:
+			valueLen = v.Len()
 		}
-		if !d.cs.DisableCapacities && valueCap != 0 {
+		if valueLen != 0 || !d.cs.DisableCapacities && valueCap != 0 {
+			d.w.Write(openParenBytes)
 			if valueLen != 0 {
-				d.w.Write(spaceBytes)
+				d.w.Write(lenEqualsBytes)
+				printInt(d.w, int64(valueLen), 10)
 			}
-			d.w.Write(capEqualsBytes)
-			printInt(d.w, int64(valueCap), 10)
+			if !d.cs.DisableCapacities && valueCap != 0 {
+				if valueLen != 0 {
+					d.w.Write(spaceBytes)
+				}
+				d.w.Write(capEqualsBytes)
+				printInt(d.w, int64(valueCap), 10)
+			}
+			d.w.Write(closeParenBytes)
+			d.w.Write(spaceBytes)
 		}
-		d.w.Write(closeParenBytes)
-		d.w.Write(spaceBytes)
 	}
 
 	// Call Stringer/error interfaces if they exist and the handle methods flag

--- a/spew/spew_test.go
+++ b/spew/spew_test.go
@@ -132,6 +132,7 @@ func initSpewTests() {
 	scsContinue := &spew.ConfigState{Indent: " ", ContinueOnMethod: true}
 	scsNoPtrAddr := &spew.ConfigState{DisablePointerAddresses: true}
 	scsNoCap := &spew.ConfigState{DisableCapacities: true}
+	scsNoLen := &spew.ConfigState{DisableLengths: true}
 
 	// Variables for tests on types which implement Stringer interface with and
 	// without a pointer receiver.
@@ -203,6 +204,7 @@ func initSpewTests() {
 		{scsNoPtrAddr, fCSSdump, "", tptr, "(*spew_test.ptrTester)({\ns: (*struct {})({\n})\n})\n"},
 		{scsNoCap, fCSSdump, "", make([]string, 0, 10), "([]string) {\n}\n"},
 		{scsNoCap, fCSSdump, "", make([]string, 1, 10), "([]string) (len=1) {\n(string) \"\"\n}\n"},
+		{scsNoLen, fCSSdump, "", make([]string, 1, 10), "([]string) {\n(string) \"\"\n}\n"},
 	}
 }
 


### PR DESCRIPTION
@dajohi This library is awesome e.g. because it creates an easy way to follow pointers on nested structs! But sometimes it a bit too verbose for my uses. Creating a `DisableLengths` would be one way to reduce the amount of noise.