### PR TITLE
feat (DisableFunctionTypePointerAddresses) hiding pointers for func fields

### DIFF
--- a/spew/config.go
+++ b/spew/config.go
@@ -98,6 +98,10 @@ type ConfigState struct {
 	// be spewed to strings and sorted by those strings.  This is only
 	// considered if SortKeys is true.
 	SpewKeys bool
+
+	// DisableFunctionTypePointerAddresses specifies whether to disable the printing of
+	// function types pointer addresses. This is useful when diffing data structures in tests.
+	DisableFunctionTypePointerAddresses bool
 }
 
 // Config is the active configuration of the top-level functions.

--- a/spew/dump.go
+++ b/spew/dump.go
@@ -433,7 +433,14 @@ func (d *dumpState) dump(v reflect.Value) {
 	case reflect.Uintptr:
 		printHexPtr(d.w, uintptr(v.Uint()))
 
-	case reflect.UnsafePointer, reflect.Chan, reflect.Func:
+	case reflect.Func:
+		if d.cs.DisableFunctionTypePointerAddresses {
+			fmt.Fprintf(d.w, "%v", v.String())
+		} else {
+			printHexPtr(d.w, v.Pointer())
+		}
+
+	case reflect.UnsafePointer, reflect.Chan:
 		printHexPtr(d.w, v.Pointer())
 
 	// There were not any other types at the time this code was written, but


### PR DESCRIPTION
Added DisableFunctionTypePointerAddresses to config.

If true it will not print the address of a Func field.

Example:
type someFuncType func(string) string
type someStructType struct {
funcField someFuncType
}

before this PR this would print:
(*spew_test.ptrFuncTester)({
funcField: (spew_test.someFuncType) 0x11a49b0
})

With this PR and DisableFunctionTypePointerAddresses = true it will print:
(*spew_test.ptrFuncTester)({
funcField: (spew_test.someFuncType) <spew_test.someFuncType Value>
})

This is important for snapshot testing, which is my use case.

Cheers