### PR TITLE
make "Dump" stdoutput atomic (non-interleaved)

### DIFF
--- a/spew/config.go
+++ b/spew/config.go
@@ -20,7 +20,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"os"
 )
 
 // ConfigState houses the configuration options used by spew to format and
@@ -271,7 +270,9 @@ See Fdump if you would prefer dumping to an arbitrary io.Writer or Sdump to
 get the formatted result as a string.
 */
 func (c *ConfigState) Dump(a ...interface{}) {
-	fdump(c, os.Stdout, a...)
+	var buf bytes.Buffer
+	fdump(c, &buf, a...)
+	fmt.Print(buf.String())
 }
 
 // Sdump returns a string with the passed arguments formatted exactly the same

--- a/spew/dump.go
+++ b/spew/dump.go
@@ -21,7 +21,6 @@ import (
 	"encoding/hex"
 	"fmt"
 	"io"
-	"os"
 	"reflect"
 	"regexp"
 	"strconv"
@@ -505,5 +504,7 @@ See Fdump if you would prefer dumping to an arbitrary io.Writer or Sdump to
 get the formatted result as a string.
 */
 func Dump(a ...interface{}) {
-	fdump(&Config, os.Stdout, a...)
+	var buf bytes.Buffer
+	fdump(&Config, &buf, a...)
+	fmt.Print(buf.String())
 }


### PR DESCRIPTION
Hello,
There is a fix for this issue [1]. "spew.Dump" output is often interrupted by other stdout. And you have to do something like fmt.Print(spew.Sdump(body)).

I do not see any drawback of this fix. If somebody wants to use os.Stdout, he/she can use "spew.Fdump"

1 - https://github.com/davecgh/go-spew/issues/94