### PR TITLE
Add DisableLengths for pairity with DisableCapacities

### DIFF
--- a/spew/config.go
+++ b/spew/config.go
@@ -71,6 +71,11 @@ type ConfigState struct {
 	// pointer addresses. This is useful when diffing data structures in tests.
 	DisablePointerAddresses bool
 
+	// DisableLengths specifies whether to disable the printing of lengths
+	// for arrays, slices, maps and channels. This is useful when diffing
+	// data structures in tests.
+	DisableLengths bool
+
 	// DisableCapacities specifies whether to disable the printing of capacities
 	// for arrays, slices, maps and channels. This is useful when diffing
 	// data structures in tests.

--- a/spew/dump.go
+++ b/spew/dump.go
@@ -282,14 +282,18 @@ func (d *dumpState) dump(v reflect.Value) {
 	case reflect.Map, reflect.String:
 		valueLen = v.Len()
 	}
-	if valueLen != 0 || !d.cs.DisableCapacities && valueCap != 0 {
+
+	showLen := !d.cs.DisableLengths && valueLen != 0
+	showCap := !d.cs.DisableCapacities && valueCap != 0
+
+	if showLen || showCap {
 		d.w.Write(openParenBytes)
-		if valueLen != 0 {
+		if showLen {
 			d.w.Write(lenEqualsBytes)
 			printInt(d.w, int64(valueLen), 10)
 		}
-		if !d.cs.DisableCapacities && valueCap != 0 {
-			if valueLen != 0 {
+		if showCap {
+			if showLen {
 				d.w.Write(spaceBytes)
 			}
 			d.w.Write(capEqualsBytes)

--- a/spew/spew_test.go
+++ b/spew/spew_test.go
@@ -132,6 +132,8 @@ func initSpewTests() {
 	scsContinue := &spew.ConfigState{Indent: " ", ContinueOnMethod: true}
 	scsNoPtrAddr := &spew.ConfigState{DisablePointerAddresses: true}
 	scsNoCap := &spew.ConfigState{DisableCapacities: true}
+	scsNoLen := &spew.ConfigState{DisableLengths: true}
+	scsNoLenNoCap := &spew.ConfigState{DisableCapacities: true, DisableLengths: true}
 
 	// Variables for tests on types which implement Stringer interface with and
 	// without a pointer receiver.
@@ -203,6 +205,10 @@ func initSpewTests() {
 		{scsNoPtrAddr, fCSSdump, "", tptr, "(*spew_test.ptrTester)({\ns: (*struct {})({\n})\n})\n"},
 		{scsNoCap, fCSSdump, "", make([]string, 0, 10), "([]string) {\n}\n"},
 		{scsNoCap, fCSSdump, "", make([]string, 1, 10), "([]string) (len=1) {\n(string) \"\"\n}\n"},
+		{scsNoLen, fCSSdump, "", make([]string, 0, 10), "([]string) (cap=10) {\n}\n"},
+		{scsNoLen, fCSSdump, "", make([]string, 1, 10), "([]string) (cap=10) {\n(string) \"\"\n}\n"},
+		{scsNoLenNoCap, fCSSdump, "", make([]string, 0, 10), "([]string) {\n}\n"},
+		{scsNoLenNoCap, fCSSdump, "", make([]string, 1, 10), "([]string) {\n(string) \"\"\n}\n"},
 	}
 }
 


### PR DESCRIPTION
For test usage, the diff will already be included, so there's no need to
list the len.

This is pretty similar to https://github.com/davecgh/go-spew/pull/58 except length-only and includes tests.