### PR TITLE
Ability to suppress fields from display

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,16 +5,8 @@ go-spew
 [![ISC License](http://img.shields.io/badge/license-ISC-blue.svg)](http://copyfree.org)
 [![Coverage Status](https://img.shields.io/coveralls/davecgh/go-spew.svg)](https://coveralls.io/r/davecgh/go-spew?branch=master)
 
-Go-spew implements a deep pretty printer for Go data structures to aid in
-debugging.  A comprehensive suite of tests with 100% test coverage is provided
-to ensure proper functionality.  See `test_coverage.txt` for the gocov coverage
-report.  Go-spew is licensed under the liberal ISC license, so it may be used in
-open source or commercial projects.
+Simply added IgnoreFieldByName(string) and IgnoreFieldByType(string) to suppress dumps.  IgnoreFieldByType will also add []name and *name so pointers to and arrays of the speciified name are also ignored.
 
-If you're interested in reading about how this package came to life and some
-of the challenges involved in providing a deep pretty printer, there is a blog
-post about it
-[here](https://web.archive.org/web/20160304013555/https://blog.cyphertite.com/go-spew-a-journey-into-dumping-go-data-structures/).
 
 ## Documentation
 
@@ -31,7 +23,7 @@ http://localhost:6060/pkg/github.com/davecgh/go-spew/spew
 ## Installation
 
 ```bash
-$ go get -u github.com/davecgh/go-spew/spew
+$ go get -u github.com/klaxxon/go-spew/spew
 ```
 
 ## Quick Start
@@ -39,7 +31,7 @@ $ go get -u github.com/davecgh/go-spew/spew
 Add this import line to the file you're working in:
 
 ```Go
-import "github.com/davecgh/go-spew/spew"
+import "github.com/klaxxon/go-spew/spew"
 ```
 
 To dump a variable with full newlines, indentation, type, and pointer

--- a/spew/config.go
+++ b/spew/config.go
@@ -106,7 +106,7 @@ type ConfigState struct {
 
 // Config is the active configuration of the top-level functions.
 // The configuration can be changed by modifying the contents of spew.Config.
-var Config = ConfigState{Indent: " ", ignoreFieldByName: make(map[string]bool), ignoreFieldByType: make(map[string]bool)}
+var Config = ConfigState{Indent: " ", ignoreFieldByName: make(map[string]bool), ignoreFieldByType: make(map[string]bool), SortKeys:true, DisablePointerAddresses:true}
 
 // Errorf is a wrapper for fmt.Errorf that treats each argument as if it were
 // passed with a Formatter interface returned by c.NewFormatter.  It returns

--- a/spew/config.go
+++ b/spew/config.go
@@ -104,9 +104,14 @@ type ConfigState struct {
 	ignoreFieldByType map[string]bool
 }
 
+func (c *ConfigState) ResetIfnoreFields() {
+	c.ignoreFieldByName = make(map[string]bool)
+	c.ignoreFieldByType = make(map[string]bool)
+}
+
 // Config is the active configuration of the top-level functions.
 // The configuration can be changed by modifying the contents of spew.Config.
-var Config = ConfigState{Indent: " ", ignoreFieldByName: make(map[string]bool), ignoreFieldByType: make(map[string]bool), SortKeys:true, DisablePointerAddresses:true}
+var Config = ConfigState{Indent: " ", ignoreFieldByName: make(map[string]bool), ignoreFieldByType: make(map[string]bool), SortKeys: true, DisablePointerAddresses: true}
 
 // Errorf is a wrapper for fmt.Errorf that treats each argument as if it were
 // passed with a Formatter interface returned by c.NewFormatter.  It returns

--- a/spew/config.go
+++ b/spew/config.go
@@ -104,7 +104,7 @@ type ConfigState struct {
 	ignoreFieldByType map[string]bool
 }
 
-func (c *ConfigState) ResetIfnoreFields() {
+func (c *ConfigState) ResetIgnoreFields() {
 	c.ignoreFieldByName = make(map[string]bool)
 	c.ignoreFieldByType = make(map[string]bool)
 }

--- a/spew/config.go
+++ b/spew/config.go
@@ -106,7 +106,7 @@ type ConfigState struct {
 
 // Config is the active configuration of the top-level functions.
 // The configuration can be changed by modifying the contents of spew.Config.
-var Config = ConfigState{Indent: " ", ignoreFieldByName: make(map[string]bool), ignoreFieldByType: make(map[string]bool), SortKeys:true, DisablePointerAddresses:true}
+var Config = ConfigState{Indent: " ", ignoreFieldByName: make(map[string]bool), ignoreFieldByType: make(map[string]bool)}
 
 // Errorf is a wrapper for fmt.Errorf that treats each argument as if it were
 // passed with a Formatter interface returned by c.NewFormatter.  It returns

--- a/spew/config.go
+++ b/spew/config.go
@@ -98,11 +98,15 @@ type ConfigState struct {
 	// be spewed to strings and sorted by those strings.  This is only
 	// considered if SortKeys is true.
 	SpewKeys bool
+
+	// Name of fields to ignore
+	ignoreFieldByName map[string]bool
+	ignoreFieldByType map[string]bool
 }
 
 // Config is the active configuration of the top-level functions.
 // The configuration can be changed by modifying the contents of spew.Config.
-var Config = ConfigState{Indent: " "}
+var Config = ConfigState{Indent: " ", ignoreFieldByName: make(map[string]bool), ignoreFieldByType: make(map[string]bool)}
 
 // Errorf is a wrapper for fmt.Errorf that treats each argument as if it were
 // passed with a Formatter interface returned by c.NewFormatter.  It returns

--- a/spew/dump.go
+++ b/spew/dump.go
@@ -413,6 +413,16 @@ func (d *dumpState) dump(v reflect.Value) {
 			vt := v.Type()
 			numFields := v.NumField()
 			for i := 0; i < numFields; i++ {
+				// Ignore?
+				n := vt.Field(i).Name
+				if _, ok := Config.ignoreFieldByName[n]; ok {
+					continue
+				}
+				n = vt.Field(i).Type.String()
+				if _, ok := Config.ignoreFieldByType[n]; ok {
+					continue
+				}
+
 				d.indent()
 				vtf := vt.Field(i)
 				d.w.Write([]byte(vtf.Name))
@@ -479,6 +489,18 @@ func Sdump(a ...interface{}) string {
 	var buf bytes.Buffer
 	fdump(&Config, &buf, a...)
 	return buf.String()
+}
+
+func IgnoreFieldByName(f string) {
+	Config.ignoreFieldByName[f] = true
+}
+
+func IgnoreFieldByType(f string) {
+	Config.ignoreFieldByType[f] = true
+	// And arrays of the type
+	Config.ignoreFieldByType["[]"+f] = true
+	// And pointers to the type
+	Config.ignoreFieldByType["*"+f] = true
 }
 
 /*


### PR DESCRIPTION
This is my first pull request.  Just the config file is what I am asking for you to consider.

Using your package and my structs contain a lot of management/housekeeping sub-structs which clutter up the output.  I needed a way to say "don't show any 'config' structs" or of the type "TempData".

Creates and maintains a map of strings for field names and types.  Two methods to add the name or type to these maps and continue statements in your recursive output builder to skip these fields if they are found.

Thank You!
