### PR TITLE
Feat: add DisableUnexported

### DIFF
--- a/spew/config.go
+++ b/spew/config.go
@@ -76,6 +76,10 @@ type ConfigState struct {
 	// data structures in tests.
 	DisableCapacities bool
 
+	// DisableUnexported specifies whether to disable the unexported fields of
+	// struct. This is useful for debugging APIs.
+	DisableUnexported bool
+
 	// ContinueOnMethod specifies whether or not recursion should continue once
 	// a custom error or Stringer interface is invoked.  The default, false,
 	// means it will print the results of invoking the custom error or Stringer

--- a/spew/dump.go
+++ b/spew/dump.go
@@ -26,6 +26,7 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+	"unicode"
 )
 
 var (
@@ -413,8 +414,11 @@ func (d *dumpState) dump(v reflect.Value) {
 			vt := v.Type()
 			numFields := v.NumField()
 			for i := 0; i < numFields; i++ {
-				d.indent()
 				vtf := vt.Field(i)
+				if d.cs.DisableUnexported && !unicode.IsUpper([]rune(vtf.Name)[0]) {
+					continue
+				}
+				d.indent()
 				d.w.Write([]byte(vtf.Name))
 				d.w.Write(colonSpaceBytes)
 				d.ignoreNextIndent = true


### PR DESCRIPTION
DisableUnexported specifies whether to disable the unexported fields of struct.
This is useful for debugging APIs.

This should close #121.