### PR TITLE
add go.mod file + add newer go versions to travis checklist.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,9 @@ go:
     - 1.9.x
     - 1.10.x
     - 1.11.x
+    - 1.12.x
+    - 1.13.x
+    - 1.14.x
     - tip
 sudo: false
 install:

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/davecgh/go-spew
+
+go 1.14


### PR DESCRIPTION
This PR adds a dummy go.mod file which enables better integration into IDEs and enables the versioning semantics introduced by go modules.

With this change you can reference this library easily in your projects go.mod file and resolution simply works.

For me this fixed the auto-import feature within the atom edition and the symbol resolution in emacs.

Additionally I added newer versions of go to the travis file.