### PR TITLE
Travis-ci: added support for ppc64le & update go 1.12 to 1.15

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,14 @@
 language: go
+arch:
+    - AMD64
+    - ppc64le
 go_import_path: github.com/davecgh/go-spew
 go:
-    - 1.6.x
-    - 1.7.x
-    - 1.8.x
-    - 1.9.x
-    - 1.10.x
     - 1.11.x
+    - 1.12.x
+    - 1.13.x
+    - 1.14.x
+    - 1.15.x
     - tip
 sudo: false
 install:


### PR DESCRIPTION
Added power support for the travis.yml file with ppc64le and update latest go versions 1.12 to 1.15. This is part of the Ubuntu distribution for ppc64le. This helps us simplify testing later when distributions are re-building and re-releasing.